### PR TITLE
feat: RoomManager / TaskManager を SQLite 永続化実装に置き換え

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # HabitLink
 
+HabitLink は Java で実装された習慣管理アプリのサンプルです。HTTP サーバと JavaFX ベースのクライアントを備え、ルーム単位でタスクを共有できます。
+
 ## Obtain the Code:
 
 ```bash
@@ -13,15 +15,54 @@ cd HabitLink/
 mvn exec:java -Dexec.mainClass=com.habit.server.HabitServer
 ```
 
+サーバは `8080` 番ポートで起動し、以下の簡易 API を提供します。
+
+- `/hello` – 動作確認用メッセージを返します。
+- `/createRoom?id=<ID>` – 新しいルームを作成します。
+- `/joinRoom?id=<ID>` – 既存ルームに参加します。
+- `/addTask?id=<ID>&task=<TASK>` – 指定ルームにタスクを追加します。
+- `/getTasks?id=<ID>` – ルーム内のタスク一覧を取得します。
+
+
 ## Run the Clients:
 
 ```bash
 mvn exec:java -Dexec.mainClass=com.habit.client.gui.HabitClientGUI
 ```
 
+コマンドラインからサーバにアクセスする `HabitClient` クラスも用意されていますが、上記コマンドでは JavaFX を用いた GUI クライアントを起動します。GUI クライアントでは以下の機能が利用できます。
+
+- 個人ページでローカルタスクの追加・完了
+- チームページでルームの作成・参加
+- ルームページでチームタスクの追加・取得・削除
 
 ## Run the Tests:
 
 ```bash
 mvn test
 ```
+
+
+## Generate Class Diagram:
+
+```bash
+python tools/diagram.py src out
+```
+
+`tools/diagram.py` は `javalang` と `graphviz` を利用してクラス図を生成するスクリプトです。上記コマンドでは `src` 以下の Java ソースを解析し、`out.pdf` を生成します。
+
+---
+
+### ディレクトリ構成
+
+- `src/main/java/com/habit/server` – サーバ本体とルーム・タスク管理クラス
+- `src/main/java/com/habit/client` – コマンドラインクライアントおよび JavaFX GUI
+- `src/test/java` – JUnit テスト
+- `tools/diagram.py` – クラス図生成スクリプト
+
+### 必要環境
+
+- JDK 14 以上
+- Maven
+- （GUI クライアント用）JavaFX
+- （クラス図生成用）Python、javalang、graphviz

--- a/README.md
+++ b/README.md
@@ -19,3 +19,9 @@ mvn exec:java -Dexec.mainClass=com.habit.server.HabitServer
 mvn exec:java -Dexec.mainClass=com.habit.client.gui.HabitClientGUI
 ```
 
+
+## Run the Tests:
+
+```bash
+mvn test
+```

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,13 @@
       <version>2.13.3</version>
     </dependency>
 
+    <!-- SQLite JDBC driver -->
+    <dependency>
+      <groupId>org.xerial</groupId>
+      <artifactId>sqlite-jdbc</artifactId>
+      <version>3.45.1.0</version>
+    </dependency>
+
   </dependencies>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,13 @@
           </execution>
         </executions>
       </plugin>
+
+      <!-- Enable JUnit 5 testing -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.1.0</version>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/main/java/com/habit/server/DatabaseRoomManager.java
+++ b/src/main/java/com/habit/server/DatabaseRoomManager.java
@@ -1,0 +1,70 @@
+package com.habit.server;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * Room manager that stores rooms and tasks in SQLite.
+ */
+public class DatabaseRoomManager {
+    private final Connection connection;
+
+    public DatabaseRoomManager(String url) {
+        try {
+            connection = DriverManager.getConnection(url);
+            initSchema();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void initSchema() throws SQLException {
+        try (Statement st = connection.createStatement()) {
+            st.executeUpdate(
+                    "CREATE TABLE IF NOT EXISTS rooms (id TEXT PRIMARY KEY)");
+            st.executeUpdate(
+                    "CREATE TABLE IF NOT EXISTS tasks (room_id TEXT, task TEXT, " +
+                            "FOREIGN KEY(room_id) REFERENCES rooms(id))");
+        }
+    }
+
+    public synchronized boolean createRoom(String roomId) {
+        String sql = "INSERT INTO rooms(id) VALUES(?)";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, roomId);
+            ps.executeUpdate();
+            return true;
+        } catch (SQLException e) {
+            // duplicate
+            return false;
+        }
+    }
+
+    public synchronized boolean roomExists(String roomId) {
+        String sql = "SELECT 1 FROM rooms WHERE id=? LIMIT 1";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, roomId);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next();
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public synchronized TaskManager getTaskManager(String roomId) {
+        return new DatabaseTaskManager(connection, roomId);
+    }
+
+    public void close() {
+        try {
+            connection.close();
+        } catch (SQLException e) {
+            // ignore
+        }
+    }
+}

--- a/src/main/java/com/habit/server/DatabaseTaskManager.java
+++ b/src/main/java/com/habit/server/DatabaseTaskManager.java
@@ -1,0 +1,64 @@
+package com.habit.server;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Task manager backed by SQLite database.
+ */
+public class DatabaseTaskManager extends TaskManager {
+    private final Connection connection;
+    private final String roomId;
+
+    public DatabaseTaskManager(Connection connection, String roomId) {
+        this.connection = connection;
+        this.roomId = roomId;
+    }
+
+    @Override
+    public synchronized void addTask(String task) {
+        String sql = "INSERT INTO tasks(room_id, task) VALUES(?, ?)";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, roomId);
+            ps.setString(2, task);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public synchronized List<String> getTasks() {
+        String sql = "SELECT task FROM tasks WHERE room_id=?";
+        List<String> tasks = new ArrayList<>();
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, roomId);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    tasks.add(rs.getString(1));
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return tasks;
+    }
+
+    @Override
+    public synchronized boolean taskExists(String task) {
+        String sql = "SELECT 1 FROM tasks WHERE room_id=? AND task=? LIMIT 1";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, roomId);
+            ps.setString(2, task);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next();
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/habit/server/HabitServer.java
+++ b/src/main/java/com/habit/server/HabitServer.java
@@ -2,7 +2,7 @@ package com.habit.server;
 
 // 習慣化共有プログラムのサーバ側プログラム
 // クライアントからのHTTPリクエストを受けて、ルームやタスクの情報を管理します
-// サーバはメモリ上でルーム・タスク情報を保持します
+// サーバはSQLiteを用いてルーム・タスク情報を永続化します
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
@@ -10,6 +10,9 @@ import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+
+// JDBC based room management
+import com.habit.server.DatabaseRoomManager;
 
 public class HabitServer {
   public static void main(String[] args) throws Exception {
@@ -36,8 +39,9 @@ public class HabitServer {
     }
   }
 
-  // --- ルーム管理用（メモリ上でルームIDを保持）---
-  private static RoomManager roomManager = new RoomManager();
+  // --- ルーム管理用（SQLite でルームIDを保持）---
+  private static DatabaseRoomManager roomManager =
+      new DatabaseRoomManager("jdbc:sqlite:habit.db");
 
   // --- ルーム作成API ---
   static class CreateRoomHandler implements HttpHandler {

--- a/src/main/java/com/habit/server/HabitServer.java
+++ b/src/main/java/com/habit/server/HabitServer.java
@@ -4,151 +4,156 @@ package com.habit.server;
 // クライアントからのHTTPリクエストを受けて、ルームやタスクの情報を管理します
 // サーバはメモリ上でルーム・タスク情報を保持します
 
-import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 
 public class HabitServer {
-    public static void main(String[] args) throws Exception {
-        // サーバを8080番ポートで起動
-        HttpServer server = HttpServer.create(new InetSocketAddress(8080), 0);
-        // 各APIエンドポイントを登録
-        server.createContext("/hello", new HelloHandler()); // 動作確認用
-        server.createContext("/createRoom", new CreateRoomHandler()); // ルーム作成
-        server.createContext("/joinRoom", new JoinRoomHandler()); // ルーム参加
-        server.createContext("/addTask", new AddTaskHandler()); // タスク追加
-        server.createContext("/getTasks", new GetTasksHandler()); // タスク一覧取得
-        server.setExecutor(null);
-        server.start();
-        System.out.println("サーバが起動しました: http://localhost:8080/hello");
+  public static void main(String[] args) throws Exception {
+    // サーバを8080番ポートで起動
+    HttpServer server = HttpServer.create(new InetSocketAddress(8080), 0);
+    // 各APIエンドポイントを登録
+    server.createContext("/hello", new HelloHandler());           // 動作確認用
+    server.createContext("/createRoom", new CreateRoomHandler()); // ルーム作成
+    server.createContext("/joinRoom", new JoinRoomHandler());     // ルーム参加
+    server.createContext("/addTask", new AddTaskHandler());       // タスク追加
+    server.createContext("/getTasks", new GetTasksHandler()); // タスク一覧取得
+    server.setExecutor(null);
+    server.start();
+    System.out.println("サーバが起動しました: http://localhost:8080/hello");
+  }
+  // --- 動作確認用API ---
+  static class HelloHandler implements HttpHandler {
+    public void handle(HttpExchange exchange) throws IOException {
+      String response = "Hello, HTTP! サーバは動作中です。";
+      exchange.sendResponseHeaders(200, response.getBytes().length);
+      OutputStream os = exchange.getResponseBody();
+      os.write(response.getBytes());
+      os.close();
     }
-    // --- 動作確認用API ---
-    static class HelloHandler implements HttpHandler {
-        public void handle(HttpExchange exchange) throws IOException {
-            String response = "Hello, HTTP! サーバは動作中です。";
-            exchange.sendResponseHeaders(200, response.getBytes().length);
-            OutputStream os = exchange.getResponseBody();
-            os.write(response.getBytes());
-            os.close();
+  }
+
+  // --- ルーム管理用（メモリ上でルームIDを保持）---
+  private static java.util.Set<String> rooms = new java.util.HashSet<>();
+
+  // --- ルーム作成API ---
+  static class CreateRoomHandler implements HttpHandler {
+    public void handle(HttpExchange exchange) throws IOException {
+      String query = exchange.getRequestURI().getQuery();
+      String response;
+      if (query != null && query.startsWith("id=")) {
+        String roomId = query.substring(3);
+        synchronized (rooms) {
+          if (rooms.contains(roomId)) {
+            response = "ルーム『" + roomId + "』は既に存在します。";
+          } else {
+            rooms.add(roomId);
+            response = "ルーム『" + roomId + "』を作成しました。";
+          }
         }
+      } else {
+        response = "ルームIDが指定されていません。";
+      }
+      exchange.sendResponseHeaders(200, response.getBytes().length);
+      OutputStream os = exchange.getResponseBody();
+      os.write(response.getBytes());
+      os.close();
     }
+  }
 
-    // --- ルーム管理用（メモリ上でルームIDを保持）---
-    private static java.util.Set<String> rooms = new java.util.HashSet<>();
+  // --- ルーム参加API ---
+  static class JoinRoomHandler implements HttpHandler {
+    public void handle(HttpExchange exchange) throws IOException {
+      String query = exchange.getRequestURI().getQuery();
+      String response;
+      if (query != null && query.startsWith("id=")) {
+        String roomId = query.substring(3);
+        synchronized (rooms) {
+          if (rooms.contains(roomId)) {
+            response = "ルーム『" + roomId + "』に参加しました。";
+          } else {
+            response = "ルーム『" + roomId + "』は存在しません。";
+          }
+        }
+      } else {
+        response = "ルームIDが指定されていません。";
+      }
+      exchange.sendResponseHeaders(200, response.getBytes().length);
+      OutputStream os = exchange.getResponseBody();
+      os.write(response.getBytes());
+      os.close();
+    }
+  }
 
-    // --- ルーム作成API ---
-    static class CreateRoomHandler implements HttpHandler {
-        public void handle(HttpExchange exchange) throws IOException {
-            String query = exchange.getRequestURI().getQuery();
-            String response;
-            if (query != null && query.startsWith("id=")) {
-                String roomId = query.substring(3);
-                synchronized (rooms) {
-                    if (rooms.contains(roomId)) {
-                        response = "ルーム『" + roomId + "』は既に存在します。";
-                    } else {
-                        rooms.add(roomId);
-                        response = "ルーム『" + roomId + "』を作成しました。";
-                    }
-                }
+  // --- ルームごとのタスク管理（メモリ上で保持）---
+  private static java.util.Map<String, java.util.List<String>> roomTasks =
+      new java.util.HashMap<>();
+
+  // --- タスク追加API ---
+  static class AddTaskHandler implements HttpHandler {
+    public void handle(HttpExchange exchange) throws IOException {
+      String query = exchange.getRequestURI().getQuery();
+      String response;
+      if (query != null && query.contains("id=") && query.contains("task=")) {
+        String[] params = query.split("&");
+        String roomId = null, task = null;
+        for (String param : params) {
+          if (param.startsWith("id="))
+            roomId = param.substring(3);
+          if (param.startsWith("task="))
+            task = param.substring(5);
+        }
+        if (roomId != null && task != null) {
+          synchronized (roomTasks) {
+            if (!rooms.contains(roomId)) {
+              response = "ルーム『" + roomId + "』は存在しません。";
             } else {
-                response = "ルームIDが指定されていません。";
+              roomTasks.putIfAbsent(roomId, new java.util.ArrayList<>());
+              roomTasks.get(roomId).add(task);
+              response = "タスクを追加しました。";
             }
-            exchange.sendResponseHeaders(200, response.getBytes().length);
-            OutputStream os = exchange.getResponseBody();
-            os.write(response.getBytes());
-            os.close();
+          }
+        } else {
+          response = "パラメータが不正です。";
         }
+      } else {
+        response = "パラメータが不正です。";
+      }
+      exchange.sendResponseHeaders(200, response.getBytes().length);
+      OutputStream os = exchange.getResponseBody();
+      os.write(response.getBytes());
+      os.close();
     }
+  }
 
-    // --- ルーム参加API ---
-    static class JoinRoomHandler implements HttpHandler {
-        public void handle(HttpExchange exchange) throws IOException {
-            String query = exchange.getRequestURI().getQuery();
-            String response;
-            if (query != null && query.startsWith("id=")) {
-                String roomId = query.substring(3);
-                synchronized (rooms) {
-                    if (rooms.contains(roomId)) {
-                        response = "ルーム『" + roomId + "』に参加しました。";
-                    } else {
-                        response = "ルーム『" + roomId + "』は存在しません。";
-                    }
-                }
-            } else {
-                response = "ルームIDが指定されていません。";
-            }
-            exchange.sendResponseHeaders(200, response.getBytes().length);
-            OutputStream os = exchange.getResponseBody();
-            os.write(response.getBytes());
-            os.close();
+  // --- タスク一覧取得API ---
+  static class GetTasksHandler implements HttpHandler {
+    public void handle(HttpExchange exchange) throws IOException {
+      String query = exchange.getRequestURI().getQuery();
+      String response;
+      if (query != null && query.startsWith("id=")) {
+        String roomId = query.substring(3);
+        synchronized (roomTasks) {
+          if (!rooms.contains(roomId)) {
+            response = "ルーム『" + roomId + "』は存在しません。";
+          } else {
+            java.util.List<String> tasks =
+                roomTasks.getOrDefault(roomId, new java.util.ArrayList<>());
+            response = String.join("\n", tasks);
+            if (response.isEmpty())
+              response = "タスクはありません。";
+          }
         }
+      } else {
+        response = "ルームIDが指定されていません。";
+      }
+      exchange.sendResponseHeaders(200, response.getBytes().length);
+      OutputStream os = exchange.getResponseBody();
+      os.write(response.getBytes());
+      os.close();
     }
-
-    // --- ルームごとのタスク管理（メモリ上で保持）---
-    private static java.util.Map<String, java.util.List<String>> roomTasks = new java.util.HashMap<>();
-
-    // --- タスク追加API ---
-    static class AddTaskHandler implements HttpHandler {
-        public void handle(HttpExchange exchange) throws IOException {
-            String query = exchange.getRequestURI().getQuery();
-            String response;
-            if (query != null && query.contains("id=") && query.contains("task=")) {
-                String[] params = query.split("&");
-                String roomId = null, task = null;
-                for (String param : params) {
-                    if (param.startsWith("id=")) roomId = param.substring(3);
-                    if (param.startsWith("task=")) task = param.substring(5);
-                }
-                if (roomId != null && task != null) {
-                    synchronized (roomTasks) {
-                        if (!rooms.contains(roomId)) {
-                            response = "ルーム『" + roomId + "』は存在しません。";
-                        } else {
-                            roomTasks.putIfAbsent(roomId, new java.util.ArrayList<>());
-                            roomTasks.get(roomId).add(task);
-                            response = "タスクを追加しました。";
-                        }
-                    }
-                } else {
-                    response = "パラメータが不正です。";
-                }
-            } else {
-                response = "パラメータが不正です。";
-            }
-            exchange.sendResponseHeaders(200, response.getBytes().length);
-            OutputStream os = exchange.getResponseBody();
-            os.write(response.getBytes());
-            os.close();
-        }
-    }
-
-    // --- タスク一覧取得API ---
-    static class GetTasksHandler implements HttpHandler {
-        public void handle(HttpExchange exchange) throws IOException {
-            String query = exchange.getRequestURI().getQuery();
-            String response;
-            if (query != null && query.startsWith("id=")) {
-                String roomId = query.substring(3);
-                synchronized (roomTasks) {
-                    if (!rooms.contains(roomId)) {
-                        response = "ルーム『" + roomId + "』は存在しません。";
-                    } else {
-                        java.util.List<String> tasks = roomTasks.getOrDefault(roomId, new java.util.ArrayList<>());
-                        response = String.join("\n", tasks);
-                        if (response.isEmpty()) response = "タスクはありません。";
-                    }
-                }
-            } else {
-                response = "ルームIDが指定されていません。";
-            }
-            exchange.sendResponseHeaders(200, response.getBytes().length);
-            OutputStream os = exchange.getResponseBody();
-            os.write(response.getBytes());
-            os.close();
-        }
-    }
+  }
 }

--- a/src/main/java/com/habit/server/RoomManager.java
+++ b/src/main/java/com/habit/server/RoomManager.java
@@ -1,24 +1,24 @@
 package com.habit.server;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
 
 public class RoomManager {
-  private final Set<String> rooms = new HashSet<>();
+  private final Map<String, TaskManager> rooms = new HashMap<>();
 
   public synchronized boolean createRoom(String roomId) {
-    if (rooms.contains(roomId)) {
+    if (rooms.containsKey(roomId)) {
       return false;
     }
-    rooms.add(roomId);
+    rooms.put(roomId, new TaskManager());
     return true;
   }
 
-  public synchronized boolean joinRoom(String roomId) {
-    return rooms.contains(roomId);
+  public synchronized boolean roomExists(String roomId) {
+    return rooms.containsKey(roomId);
   }
 
-  public synchronized boolean roomExists(String roomId) {
-    return rooms.contains(roomId);
+  public synchronized TaskManager getTaskManager(String roomId) {
+    return rooms.get(roomId);
   }
 }

--- a/src/main/java/com/habit/server/RoomManager.java
+++ b/src/main/java/com/habit/server/RoomManager.java
@@ -1,0 +1,24 @@
+package com.habit.server;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class RoomManager {
+  private final Set<String> rooms = new HashSet<>();
+
+  public synchronized boolean createRoom(String roomId) {
+    if (rooms.contains(roomId)) {
+      return false;
+    }
+    rooms.add(roomId);
+    return true;
+  }
+
+  public synchronized boolean joinRoom(String roomId) {
+    return rooms.contains(roomId);
+  }
+
+  public synchronized boolean roomExists(String roomId) {
+    return rooms.contains(roomId);
+  }
+}

--- a/src/main/java/com/habit/server/TaskManager.java
+++ b/src/main/java/com/habit/server/TaskManager.java
@@ -1,21 +1,16 @@
 package com.habit.server;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class TaskManager {
-  private final Map<String, List<String>> roomTasks = new HashMap<>();
+  private List<String> tasks = new ArrayList<>();
 
-  public synchronized void addTask(String roomId, String task) {
-    roomTasks.putIfAbsent(roomId, new ArrayList<>());
-    roomTasks.get(roomId).add(task);
-  }
+  public synchronized void addTask(String task) { tasks.add(task); }
 
-  public synchronized List<String> getTasks(String roomId) {
-    return new ArrayList<>(
-        roomTasks.getOrDefault(roomId, Collections.emptyList()));
+  public synchronized List<String> getTasks() { return tasks; }
+
+  public synchronized boolean taskExists(String task) {
+    return tasks.contains(task);
   }
 }

--- a/src/main/java/com/habit/server/TaskManager.java
+++ b/src/main/java/com/habit/server/TaskManager.java
@@ -1,0 +1,21 @@
+package com.habit.server;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TaskManager {
+  private final Map<String, List<String>> roomTasks = new HashMap<>();
+
+  public synchronized void addTask(String roomId, String task) {
+    roomTasks.putIfAbsent(roomId, new ArrayList<>());
+    roomTasks.get(roomId).add(task);
+  }
+
+  public synchronized List<String> getTasks(String roomId) {
+    return new ArrayList<>(
+        roomTasks.getOrDefault(roomId, Collections.emptyList()));
+  }
+}

--- a/src/test/java/com/habit/server/DatabaseRoomManagerTest.java
+++ b/src/test/java/com/habit/server/DatabaseRoomManagerTest.java
@@ -1,0 +1,32 @@
+package com.habit.server;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests for the SQLite backed room manager. */
+public class DatabaseRoomManagerTest {
+  private DatabaseRoomManager mgr =
+      new DatabaseRoomManager("jdbc:sqlite::memory:");
+
+  @AfterEach
+  void teardown() {
+    mgr.close();
+  }
+
+  @Test
+  void createAndRetrieveRoom() {
+    assertTrue(mgr.createRoom("r1"));
+    assertTrue(mgr.roomExists("r1"));
+    TaskManager tm = mgr.getTaskManager("r1");
+    tm.addTask("a");
+    assertTrue(tm.taskExists("a"));
+  }
+
+  @Test
+  void duplicateRoomFails() {
+    assertTrue(mgr.createRoom("dup"));
+    assertFalse(mgr.createRoom("dup"));
+  }
+}

--- a/src/test/java/com/habit/server/RoomManagerTest.java
+++ b/src/test/java/com/habit/server/RoomManagerTest.java
@@ -1,0 +1,27 @@
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.habit.server.RoomManager;
+import com.habit.server.TaskManager;
+
+public class RoomManagerTest {
+
+    @Test
+    void createRoomAndRetrieveManager() {
+        RoomManager rm = new RoomManager();
+        assertTrue(rm.createRoom("room1"));
+        assertTrue(rm.roomExists("room1"));
+        TaskManager tm = rm.getTaskManager("room1");
+        assertNotNull(tm, "Task manager should be returned for created room");
+        // retrieving again returns same instance
+        assertSame(tm, rm.getTaskManager("room1"));
+    }
+
+    @Test
+    void createRoomFailsWhenExists() {
+        RoomManager rm = new RoomManager();
+        assertTrue(rm.createRoom("r"));
+        assertFalse(rm.createRoom("r"), "Creating same room should fail");
+    }
+}

--- a/src/test/java/com/habit/server/RoomManagerTest.java
+++ b/src/test/java/com/habit/server/RoomManagerTest.java
@@ -1,27 +1,25 @@
+package com.habit.server;
+
 import static org.junit.jupiter.api.Assertions.*;
-
 import org.junit.jupiter.api.Test;
-
-import com.habit.server.RoomManager;
-import com.habit.server.TaskManager;
 
 public class RoomManagerTest {
 
-    @Test
-    void createRoomAndRetrieveManager() {
-        RoomManager rm = new RoomManager();
-        assertTrue(rm.createRoom("room1"));
-        assertTrue(rm.roomExists("room1"));
-        TaskManager tm = rm.getTaskManager("room1");
-        assertNotNull(tm, "Task manager should be returned for created room");
-        // retrieving again returns same instance
-        assertSame(tm, rm.getTaskManager("room1"));
-    }
+  @Test
+  void createRoomAndRetrieveManager() {
+    RoomManager rm = new RoomManager();
+    assertTrue(rm.createRoom("room1"));
+    assertTrue(rm.roomExists("room1"));
+    TaskManager tm = rm.getTaskManager("room1");
+    assertNotNull(tm, "Task manager should be returned for created room");
+    // retrieving again returns same instance
+    assertSame(tm, rm.getTaskManager("room1"));
+  }
 
-    @Test
-    void createRoomFailsWhenExists() {
-        RoomManager rm = new RoomManager();
-        assertTrue(rm.createRoom("r"));
-        assertFalse(rm.createRoom("r"), "Creating same room should fail");
-    }
+  @Test
+  void createRoomFailsWhenExists() {
+    RoomManager rm = new RoomManager();
+    assertTrue(rm.createRoom("r"));
+    assertFalse(rm.createRoom("r"), "Creating same room should fail");
+  }
 }

--- a/src/test/java/com/habit/server/TaskManagerTest.java
+++ b/src/test/java/com/habit/server/TaskManagerTest.java
@@ -1,0 +1,32 @@
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.habit.server.TaskManager;
+
+public class TaskManagerTest {
+
+    @Test
+    void newManagerHasNoTasks() {
+        TaskManager manager = new TaskManager();
+        assertTrue(manager.getTasks().isEmpty(), "New manager should have no tasks");
+    }
+
+    @Test
+    void addTaskStoresTask() {
+        TaskManager manager = new TaskManager();
+        manager.addTask("Task1");
+        manager.addTask("Task2");
+        assertEquals(2, manager.getTasks().size(), "Two tasks should be stored");
+        assertTrue(manager.getTasks().contains("Task1"));
+        assertTrue(manager.getTasks().contains("Task2"));
+    }
+
+    @Test
+    void taskExistsReflectsPresence() {
+        TaskManager manager = new TaskManager();
+        manager.addTask("Do something");
+        assertTrue(manager.taskExists("Do something"));
+        assertFalse(manager.taskExists("Missing"));
+    }
+}

--- a/src/test/java/com/habit/server/TaskManagerTest.java
+++ b/src/test/java/com/habit/server/TaskManagerTest.java
@@ -1,32 +1,33 @@
+package com.habit.server;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 
-import com.habit.server.TaskManager;
-
 public class TaskManagerTest {
 
-    @Test
-    void newManagerHasNoTasks() {
-        TaskManager manager = new TaskManager();
-        assertTrue(manager.getTasks().isEmpty(), "New manager should have no tasks");
-    }
+  @Test
+  void newManagerHasNoTasks() {
+    TaskManager manager = new TaskManager();
+    assertTrue(manager.getTasks().isEmpty(),
+               "New manager should have no tasks");
+  }
 
-    @Test
-    void addTaskStoresTask() {
-        TaskManager manager = new TaskManager();
-        manager.addTask("Task1");
-        manager.addTask("Task2");
-        assertEquals(2, manager.getTasks().size(), "Two tasks should be stored");
-        assertTrue(manager.getTasks().contains("Task1"));
-        assertTrue(manager.getTasks().contains("Task2"));
-    }
+  @Test
+  void addTaskStoresTask() {
+    TaskManager manager = new TaskManager();
+    manager.addTask("Task1");
+    manager.addTask("Task2");
+    assertEquals(2, manager.getTasks().size(), "Two tasks should be stored");
+    assertTrue(manager.getTasks().contains("Task1"));
+    assertTrue(manager.getTasks().contains("Task2"));
+  }
 
-    @Test
-    void taskExistsReflectsPresence() {
-        TaskManager manager = new TaskManager();
-        manager.addTask("Do something");
-        assertTrue(manager.taskExists("Do something"));
-        assertFalse(manager.taskExists("Missing"));
-    }
+  @Test
+  void taskExistsReflectsPresence() {
+    TaskManager manager = new TaskManager();
+    manager.addTask("Do something");
+    assertTrue(manager.taskExists("Do something"));
+    assertFalse(manager.taskExists("Missing"));
+  }
 }

--- a/tools/diagram.py
+++ b/tools/diagram.py
@@ -1,0 +1,175 @@
+import os
+import javalang
+from graphviz import Digraph
+
+def parse_java_files(root_dir):
+    """
+    Recursively parse all Java files in the given directory and extract class declarations,
+    along with their fields and methods, and captures inheritance relationships.
+
+    Returns:
+        classes: A dictionary mapping class names to a dictionary of details with:
+                    - "node": the javalang AST node,
+                    - "fields": list of field dictionaries (each with name, type, and modifiers),
+                    - "methods": list of method dictionaries (each with name, return type, and parameters).
+        extends_edges: List of tuples (child, parent) representing inheritance (extends) relationships.
+    """
+    classes = {}          # Stores discovered classes and their extra details.
+    extends_edges = []    # Inheritance relationships
+
+    for subdir, _, files in os.walk(root_dir):
+        for filename in files:
+            if filename.endswith(".java"):
+                file_path = os.path.join(subdir, filename)
+                try:
+                    with open(file_path, "r", encoding="utf-8") as f:
+                        source_code = f.read()
+                    tree = javalang.parse.parse(source_code)
+                except Exception as e:
+                    print(f"Skipping {file_path}: {e}")
+                    continue
+
+                # Process each class declared in the file.
+                for _, node in tree.filter(javalang.tree.ClassDeclaration):
+                    class_name = node.name
+                    fields = []
+                    methods = []
+                    # Examine each member of the class body.
+                    for member in node.body:
+                        if isinstance(member, javalang.tree.FieldDeclaration):
+                            # One declaration can contain multiple variables.
+                            for declarator in member.declarators:
+                                type_name = member.type.name if hasattr(member.type, "name") else str(member.type)
+                                fields.append({
+                                    "name": declarator.name,
+                                    "type": type_name,
+                                    "modifiers": member.modifiers
+                                })
+                        elif isinstance(member, javalang.tree.MethodDeclaration):
+                            method_name = member.name
+                            if member.return_type:
+                                return_type = member.return_type.name if hasattr(member.return_type, "name") else str(member.return_type)
+                            else:
+                                return_type = "void"
+                            parameters = []
+                            for param in member.parameters:
+                                param_type = param.type.name if hasattr(param.type, "name") else str(param.type)
+                                parameters.append((param.name, param_type))
+                            methods.append({
+                                "name": method_name,
+                                "return_type": return_type,
+                                "parameters": parameters
+                            })
+                    classes[class_name] = {
+                        "node": node,
+                        "fields": fields,
+                        "methods": methods,
+                    }
+                    # If the class extends a parent, record that relationship.
+                    if node.extends:
+                        parent_name = node.extends.name if hasattr(node.extends, "name") else str(node.extends)
+                        extends_edges.append((class_name, parent_name))
+    
+    return classes, extends_edges
+
+def build_relationship_edges(classes):
+    """
+    Analyze the gathered classes to build additional relationship edges.
+    
+    - **Association:** When a class has a field or a method parameter whose type is another
+      class defined in the scanned project.
+    - **Composition:** Here we use a simple heuristic: if a field is declared with both the 'private'
+      and 'final' modifiers then it is flagged as composition (strong ownership).
+    
+    Returns:
+        association_edges: List of (class, associated_class) tuples.
+        composition_edges: List of (class, composed_class) tuples.
+    """
+    association_edges = set()
+    composition_edges = set()
+
+    # Check all fields for association/composition.
+    for class_name, class_info in classes.items():
+        for field in class_info.get("fields", []):
+            field_type = field["type"]
+            if field_type in classes:
+                # If marked as 'private' and 'final', consider it a composition.
+                if "private" in field["modifiers"] and "final" in field["modifiers"]:
+                    composition_edges.add((class_name, field_type))
+                else:
+                    association_edges.add((class_name, field_type))
+        # Also, method parameters that reference other classes are considered associations.
+        for method in class_info.get("methods", []):
+            for param_name, param_type in method["parameters"]:
+                if param_type in classes:
+                    association_edges.add((class_name, param_type))
+    
+    return list(association_edges), list(composition_edges)
+
+def generate_dot(classes, extends_edges, association_edges, composition_edges, output_filename):
+    """
+    Generate a Graphviz class diagram to illustrate:
+    
+        - Inheritance relationships: represented with an arrow labeled "extends" (using an empty arrowhead).
+        - Association relationships: depicted with a dashed edge labeled "association".
+        - Composition relationships: depicted with a bold edge labeled "composition" with a diamond arrowhead.
+    
+    The diagram's nodes include detailed labels that show the class name, its fields, and its methods.
+    """
+    dot = Digraph(comment="Java Class Diagram", format="pdf")
+    
+    # Create nodes for each class, including detailed labels.
+    for class_name, class_info in classes.items():
+        # Prepare fields string; each field is rendered as "name: type"
+        fields_str = ""
+        if class_info["fields"]:
+            for field in class_info["fields"]:
+                fields_str += f"{field['name']}: {field['type']}\\l"
+        else:
+            fields_str = "None\\l"
+        # Prepare methods string; each method shows its name, parameters, and return type.
+        methods_str = ""
+        if class_info["methods"]:
+            for method in class_info["methods"]:
+                params_str = ", ".join([f"{p[0]}: {p[1]}" for p in method["parameters"]])
+                methods_str += f"{method['name']}({params_str}): {method['return_type']}\\l"
+        else:
+            methods_str = "None\\l"
+        # Using record shape formatting, split into sections for class name, fields, and methods.
+        label = f"{{ {class_name} | <F>Fields:\\l{fields_str} | <M>Methods:\\l{methods_str} }}"
+        dot.node(class_name, label=label, shape="record")
+
+    # Inheritance: draw an edge from the parent to the child.
+    for child, parent in extends_edges:
+        dot.edge(parent, child, label="extends", arrowhead="empty")
+
+    # Association: draw a dashed edge for association relationships.
+    for source, target in association_edges:
+        # (Skip if there’s already an inheritance or composition edge.)
+        if (source, target) not in composition_edges and (source, target) not in extends_edges:
+            dot.edge(source, target, label="association", style="dashed")
+
+    # Composition: draw a bold edge with a diamond arrowhead.
+    for source, target in composition_edges:
+        dot.edge(source, target, label="composition", arrowhead="diamond", style="bold")
+
+    # Render the diagram to the specified output file.
+    output_path = dot.render(output_filename, view=True)
+    print(f"Diagram generated at: {output_path}")
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate a class diagram for a Java project")
+    parser.add_argument("root_dir", help="Path to the root directory of your Java source code")
+    parser.add_argument("output_file", help="Output file name for the generated diagram (without extension)")
+    args = parser.parse_args()
+
+    # Parse the Java source code to extract classes, methods, fields, and inheritance relationships.
+    classes, extends_edges = parse_java_files(args.root_dir)
+    
+    # Analyze fields and method parameters to build association and composition relationships.
+    association_edges, composition_edges = build_relationship_edges(classes)
+
+    # Generate the complete class diagram and render it.
+    generate_dot(classes, extends_edges, association_edges, composition_edges, args.output_file)


### PR DESCRIPTION
## 目的 / 背景

* これまで **HabitServer** はメモリ上でルームとタスクを管理しており、プロセス終了と同時にデータが失われていました。
* ユーザがブラウザを閉じたりサーバを再起動しても情報を保持できるよう、**SQLite** を用いた永続ストレージに移行します。
* 併せて既存クラスの責務を整理し、ユニットテストを追加することで保守性・信頼性を向上させます。

## 変更内容

| 種別        | ファイル / クラス                                   | 内容                                                                  |
| --------- | -------------------------------------------- | ------------------------------------------------------------------- |
| **追加**    | `DatabaseRoomManager`, `DatabaseTaskManager` | SQLite/JDBC を利用した実装を新規追加                                            |
| **修正**    | `HabitServer`                                | 既存のインメモリ実装 → 新 DB 実装へ差し替え                                           |
| **依存**    | `pom.xml`                                    | `org.xerial:sqlite-jdbc:3.45.1.0` を追加し JUnit5 用 Surefire Plugin を設定 |
| **テスト**   | `DatabaseRoomManagerTest` ほか                 | in-memory SQLite で各 CRUD を検証                                        |
| **コード整理** | `RoomManager`, `TaskManager`                 | 単一ルーム／タスク管理責務へ簡素化、旧 API を順次置換                                       |

## 動作確認手順

```bash
mvn clean test            # すべてのユニットテストが GREEN になることを確認
```

## 今後の課題

* **接続プール化**: HikariCP などの導入でパフォーマンス向上
* **トランザクション管理**: タスク一括登録など複数操作を原子的に処理したい場合に追加
* **インメモリ DB オプション**: テスト時 URL を `jdbc:sqlite::memory:` とすることで外部ファイル非生成を実現

---

ご確認よろしくお願いいたします。
