### PR TITLE
Feature/tsuji/monitor tasks

### DIFF
--- a/src/main/java/com/habit/server/controller/UserTaskStatusController.java
+++ b/src/main/java/com/habit/server/controller/UserTaskStatusController.java
@@ -317,11 +317,23 @@ public class UserTaskStatusController {
             }
         }
     }
+
+    /**
+     * ユーザーのタスク完了APIハンドラー
+     * 【処理内容】
+     * 1. POSTメソッドでリクエストを受け取る
+     * 2. リクエストボディからuserId, taskId, dateを取得
+     * 3. UserTaskStatusRepositoryを使用して、指定ユーザーの
+     *    タスク完了ステータスを更新または新規作成
+     * 4. タスク完了後、即座にタスク再設定処理を実行
+     * 5. レスポンスとして完了メッセージを返却
+     */
     public static class CompleteUserTaskHandler implements com.sun.net.httpserver.HttpHandler {
         @Override
         public void handle(com.sun.net.httpserver.HttpExchange exchange) throws java.io.IOException {
             java.io.OutputStream os = null;
             try {
+                // リクエストメソッドのチェック
                 if (!"POST".equals(exchange.getRequestMethod())) {
                     String response = "POSTメソッドのみ対応";
                     exchange.sendResponseHeaders(405, response.getBytes().length);
@@ -329,6 +341,7 @@ public class UserTaskStatusController {
                     os.write(response.getBytes());
                     return;
                 }
+                // リクエストボディの解析
                 byte[] bodyBytes = exchange.getRequestBody().readAllBytes();
                 String bodyStr = (bodyBytes != null) ? new String(bodyBytes, java.nio.charset.StandardCharsets.UTF_8) : "";
                 final String[] userId = {null};
@@ -350,15 +363,22 @@ public class UserTaskStatusController {
                     UserTaskStatusRepository repo = new UserTaskStatusRepository();
                     com.habit.server.repository.TaskRepository taskRepo = new com.habit.server.repository.TaskRepository();
                     
-                    // 既存のステータスがあれば取得、なければ新規作成
-                    java.util.Optional<com.habit.domain.UserTaskStatus> optStatus = repo.findByUserIdAndTaskIdAndDate(userId[0], taskId[0], date);
-                    com.habit.domain.UserTaskStatus status = optStatus.orElseGet(() ->
-                        new com.habit.domain.UserTaskStatus(userId[0], taskId[0], date, false)
-                    );
+                    // 既存のステータスがなければエラーを返す
+                    java.util.Optional<com.habit.domain.UserTaskStatus> optStatus = repo.findByUserIdAndTaskId(userId[0], taskId[0]);
+                    if (optStatus.isEmpty()) {
+                        response = "エラー: 該当のタスクステータスが見つかりません。";
+                        exchange.getResponseHeaders().set("Content-Type", "text/plain; charset=UTF-8");
+                        exchange.sendResponseHeaders(404, response.getBytes("UTF-8").length);
+                        os = exchange.getResponseBody();
+                        os.write(response.getBytes("UTF-8"));
+                        return;
+                    }
+                    com.habit.domain.UserTaskStatus status = optStatus.get();
+                    // タスク完了ステータスを更新(保存)
                     status.setDone(true);
                     repo.save(status);
                     
-                    // ★即座のタスク再設定処理を追加★
+                    // 即座にタスクを再設定
                     try {
                         // 完了したタスクの情報を取得
                         com.habit.server.repository.TeamRepository teamRepo = new com.habit.server.repository.TeamRepository();
@@ -385,16 +405,16 @@ public class UserTaskStatusController {
                             com.habit.server.service.TaskAutoResetService autoResetService =
                                 new com.habit.server.service.TaskAutoResetService(taskRepo, repo);
                             
-                            System.out.println("[CompleteUserTaskHandler] 即座のタスク再設定を実行: taskId=" + taskId[0] +
+                            System.out.println("[CompleteUserTaskHandler] 達成時のタスク再設定を実行: taskId=" + taskId[0] +
                                 ", userId=" + userId[0] + ", cycleType=" + completedTask.getCycleType());
                             
                             boolean resetSuccess = autoResetService.createNextTaskInstanceImmediately(
                                 completedTask, userId[0], date, teamId);
                             
                             if (resetSuccess) {
-                                System.out.println("[CompleteUserTaskHandler] 即座のタスク再設定成功");
+                                System.out.println("[CompleteUserTaskHandler] 達成時のタスク再設定成功");
                             } else {
-                                System.out.println("[CompleteUserTaskHandler] 即座のタスク再設定スキップまたは対象外");
+                                System.out.println("[CompleteUserTaskHandler] 達成時のタスク再設定スキップまたは対象外");
                             }
                         } else {
                             System.out.println("[CompleteUserTaskHandler] 完了タスクが見つかりません: taskId=" + taskId[0]);

--- a/src/main/java/com/habit/server/repository/UserTaskStatusRepository.java
+++ b/src/main/java/com/habit/server/repository/UserTaskStatusRepository.java
@@ -132,7 +132,25 @@ public class UserTaskStatusRepository {
         return result;
     }
 
-    // ユーザID・タスクID・日付で検索
+    // ユーザID・タスクIDで検索
+    public Optional<UserTaskStatus> findByUserIdAndTaskId(String userId, String taskId) {
+        try (Connection conn = DriverManager.getConnection(DB_URL)) {
+            String sql = "SELECT * FROM user_task_statuses WHERE userId = ? AND taskId = ?";
+            try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
+                pstmt.setString(1, userId);
+                pstmt.setString(2, taskId);
+                ResultSet rs = pstmt.executeQuery();
+                if (rs.next()) {
+                    return Optional.of(mapRowToStatus(rs));
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return Optional.empty();
+    }
+
+    // ユーザID・タスクID・日付で検索 → 廃止すべき
     public Optional<UserTaskStatus> findByUserIdAndTaskIdAndDate(String userId, String taskId, LocalDate date) {
         try (Connection conn = DriverManager.getConnection(DB_URL)) {
             String sql = "SELECT * FROM user_task_statuses WHERE userId = ? AND taskId = ? AND date = ?";

--- a/src/main/java/com/habit/server/scheduler/TaskAutoResetScheduler.java
+++ b/src/main/java/com/habit/server/scheduler/TaskAutoResetScheduler.java
@@ -29,8 +29,8 @@ public class TaskAutoResetScheduler {
     private final TaskAutoResetService taskAutoResetService;
     private final ScheduledExecutorService scheduler;
     
-    // 実行間隔（1時間ごと）- 変更したい場合はここを修正
-    private static final int EXECUTION_INTERVAL_HOURS = 1;
+    // 実行間隔（1分ごと）- 変更したい場合はここを修正
+    private static final int EXECUTION_INTERVAL_MINUTES = 1;
     
     public TaskAutoResetScheduler() {
         this.taskAutoResetService = new TaskAutoResetService(
@@ -45,16 +45,16 @@ public class TaskAutoResetScheduler {
      *
      * 【実行タイミング】
      * - 初回実行: サーバー起動60秒後
-     * - 以降: 1時間ごとに実行
+     * - 以降: 1分ごとに実行
      *
      * 【スケジューラーの種類】
      * scheduleAtFixedRate: 前回の実行開始時刻から固定間隔で実行
-     * （処理時間に関係なく、1時間ごとに確実に実行される）
+     * （処理時間に関係なく、1分ごとに確実に実行される）
      */
     public void start() {
         long initialDelay = 60; // 1分後に初回実行（サーバー起動直後の負荷を避ける）
-        long period = 60; // 1時間間隔（秒）
-        
+        long period = EXECUTION_INTERVAL_MINUTES * 60; // 1分間隔（秒）
+
         scheduler.scheduleAtFixedRate(
             this::executeAutoReset, // 実行するメソッド
             initialDelay,           // 初回実行までの遅延
@@ -63,7 +63,7 @@ public class TaskAutoResetScheduler {
         );
         
         System.out.println("タスク自動再設定スケジューラーを開始しました。");
-        System.out.println("実行間隔: " + EXECUTION_INTERVAL_HOURS + "時間ごと");
+        System.out.println("実行間隔: " + EXECUTION_INTERVAL_MINUTES + "分ごと");
         System.out.println("初回実行まで: " + initialDelay + "秒");
     }
     

--- a/src/main/java/com/habit/server/scheduler/TaskAutoResetScheduler.java
+++ b/src/main/java/com/habit/server/scheduler/TaskAutoResetScheduler.java
@@ -13,17 +13,9 @@ import java.time.temporal.ChronoUnit;
 
 /**
  * タスク自動再設定の定期実行スケジューラー
- *
- * 【目的】
- * タスクの自動再設定を定期的に実行し、ユーザーの習慣継続をサポート
- *
- * 【実行間隔】
- * 1時間ごとに実行（サーバー起動1分後から開始）
- *
- * 【利点】
- * - タスク完了後、最大1時間で次のタスクが自動生成
- * - 期限切れタスクの早期検出・新規作成
- * - ユーザーが「今日のタスクがない」状況を回避
+ *  タスクの自動再設定を定期的に実行する。
+ *  1分ごとに実行
+ * 期限切れタスクの検出が目的
  */
 public class TaskAutoResetScheduler {
     private final TaskAutoResetService taskAutoResetService;
@@ -37,23 +29,18 @@ public class TaskAutoResetScheduler {
             new TaskRepository(),
             new UserTaskStatusRepository()
         );
-        this.scheduler = Executors.newScheduledThreadPool(1);
+        this.scheduler = Executors.newScheduledThreadPool(1); // スレッドプールのサイズは1（単一スレッドで実行）
     }
     
     /**
-     * スケジューラーを開始
-     *
-     * 【実行タイミング】
-     * - 初回実行: サーバー起動60秒後
-     * - 以降: 1分ごとに実行
-     *
-     * 【スケジューラーの種類】
-     * scheduleAtFixedRate: 前回の実行開始時刻から固定間隔で実行
+     * スケジューラーの開始メソッド
+     *  1分ごとに実行
+     *  scheduleAtFixedRate: 前回の実行開始時刻から固定間隔で実行
      * （処理時間に関係なく、1分ごとに確実に実行される）
      */
     public void start() {
         long initialDelay = 60; // 1分後に初回実行（サーバー起動直後の負荷を避ける）
-        long period = EXECUTION_INTERVAL_MINUTES * 60; // 1分間隔（秒）
+        long period = EXECUTION_INTERVAL_MINUTES * 60; // 1分間隔（単位: 秒）
 
         scheduler.scheduleAtFixedRate(
             this::executeAutoReset, // 実行するメソッド
@@ -68,9 +55,7 @@ public class TaskAutoResetScheduler {
     }
     
     /**
-     * スケジューラーを停止
-     *
-     * 【停止手順】
+     * スケジューラーの停止メソッド
      * 1. 新しいタスクの受付を停止
      * 2. 60秒間実行中のタスクの完了を待機
      * 3. 完了しない場合は強制終了
@@ -91,17 +76,10 @@ public class TaskAutoResetScheduler {
         System.out.println("タスク自動再設定スケジューラーを停止しました。");
     }
     
-    // calculateInitialDelayメソッドは不要になったため削除
-    
     /**
-     * 自動再設定を実行
-     *
-     * 【実行内容】
-     * TaskAutoResetService.runScheduledCheck()を呼び出し、
-     * 全チームのタスクを自動再設定
-     *
-     * 【エラーハンドリング】
-     * 例外が発生してもスケジューラーは停止せず、次回実行を継続
+     * 自動再設定を実行するメソッド
+     *  TaskAutoResetService.runScheduledCheck()を呼び出し、全チームのタスクを自動再設定
+     *  例外が発生してもスケジューラーは停止せず、次回実行を継続
      */
     private void executeAutoReset() {
         try {


### PR DESCRIPTION
このプルリクエストは、Habitアプリのタスク処理を改善するためのいくつかの変更を導入するもので、特に期限切れタスクの管理、タスクのリセットロジック、スケジューリングの間隔に焦点を当てています。主な更新内容には、クライアントUIでの期限切れタスクのスキップ、サーバー側でのタスク選択と完了ロジックの改善、タスク自動リセットスケジューラの頻度向上が含まれます。

### クライアント側の変更点：
* `PersonalPageController` を更新し、`updateTaskTiles` メソッドで期限切れのタスクを表示しないようにしました。これにより、ユーザーには関連性のあるタスクのみが表示されます。
* `getRemainingTimeString` メソッドを強化し、期限時刻と期限日の両方を考慮するようにして、より正確な残り時間の計算を提供します。
* `getRemainingTimeAndDaysString` を調整し、更新された `getRemainingTimeString` のロジックをサポートすることで、タスクの締め切り表示の一貫性を確保しました。[[1]](diffhunk://#diff-21e3bc0e44b6dd89a05577f6137ec1dbfd039074a3a06681ff46b43c0d8b10d1L207-R227) [[2]](diffhunk://#diff-21e3bc0e44b6dd89a05577f6137ec1dbfd039074a3a06681ff46b43c0d8b10d1L229-R249)

---

### サーバー側の変更点：
* `UserTaskStatusController` をリファクタリングし、表示するタスクを選択する際に期限切れのタスクを除外し、タスクステータスの存在を確認することで、タスクの完了をより堅牢に処理するようにしました。[[1]](diffhunk://#diff-a8274aeea8fa51db9b006638a8c8adea97299aaac8e6f84129552ca633825405L185-R217) [[2]](diffhunk://#diff-a8274aeea8fa51db9b006638a8c8adea97299aaac8e6f84129552ca633825405L328-R381)
* `UserTaskStatusRepository` に新しい `findByUserIdAndTaskId` メソッドを導入し、より効率的なタスクステータスの取得を可能にしました。古い `findByUserIdAndTaskIdAndDate` メソッドは非推奨となります。

---

### スケジューラとサービスの更新点：
* タスク自動リセットスケジューラの間隔を1時間から1分に短縮し、期限切れタスクの検出とタスクのリセットを迅速化しました。[[1]](diffhunk://#diff-73471cbc05553026b590fcf9de4445400488a09bc7f624f78f8dc701a0b02d19L16-R43) [[2]](diffhunk://#diff-73471cbc05553026b590fcf9de4445400488a09bc7f624f78f8dc701a0b02d19L66-R58)
* `TaskAutoResetService` を更新し、不要なチェックを削除してロジックを簡素化し、期限切れタスクの処理を通常のタスク完了の振る舞いと一致させました。[[1]](diffhunk://#diff-4bd716d5e8c922a1dba498f1d2081f9411144ed9b3da42d973ad7a3b68f4c647L90-R85) [[2]](diffhunk://#diff-4bd716d5e8c922a1dba498f1d2081f9411144ed9b3da42d973ad7a3b68f4c647L51-L79)

### 今後の方針
タスクの期限時刻を廃止し、日時のみで判定を行うようにする。
UserTaskStatusやTaskの構造を見直す