### PR TITLE
チームトップ画面下部の、todayTaskListとchatListを改良

### DIFF
--- a/src/main/resources/com/habit/client/gui/TeamTop.fxml
+++ b/src/main/resources/com/habit/client/gui/TeamTop.fxml
@@ -25,7 +25,7 @@
                 </VBox>
                 <VBox>
                     <Label text="チームチャット"/>
-                    <ListView fx:id="chatList" prefHeight="90" prefWidth="90"/>
+                    <ListView fx:id="chatList" prefHeight="90" prefWidth="300"/>
                 </VBox>
             </HBox>
         </VBox>


### PR DESCRIPTION
このプルリクエストでは、`TeamTopController` クラスとその関連する GUI に複数の機能強化を導入し、タスクのフィルタリング、チャットメッセージの処理、およびユーザーインターフェースのレイアウトを改善します。最も重要な変更点には、タスクのフィルタリングロジックを `PersonalPage` と一致させること、ドメインモデルを使用してチャットログの処理を改善すること、および GUI 内のチャットリストの表示幅を更新することが含まれます。

### タスクフィルタリングの機能強化:
* `loadTeamTasksAndUserTasks` メソッドを、タスクの取得に `PersonalPage` と同じ API を使用するように更新しました。これには、期限切れのタスクを期限に基づいてフィルタリングする機能が含まれます。デバッグ目的のためのログ記録を追加しました。

### チャットログの改善:
* `loadChatLog` メソッドをリファクタリングし、タイムスタンプに基づいてチャットメッセージの解析と並べ替えに `Message` ドメインモデルを使用するようにしました。チャットの表示形式を再フォーマットし、ユーザー名とメッセージ内容をより見やすい形式で表示するようにしました。

### GUI の更新:
* `TeamTop.fxml` ファイル内の `chatList` の幅を拡大し、チャットメッセージの読みやすさを向上させました。