### PR TITLE
サーバ起動時にタスク再設定を実行

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ msg
 target/*
 .cache/*
 habit.db
+last_execution.log

--- a/src/main/java/com/habit/server/HabitServer.java
+++ b/src/main/java/com/habit/server/HabitServer.java
@@ -78,6 +78,9 @@ public class HabitServer {
     taskAutoResetScheduler = new TaskAutoResetScheduler(taskAutoResetService);
     taskAutoResetController = new TaskAutoResetController(taskAutoResetService);
 
+    // サーバー起動時に未処理のタスク更新を実行
+    taskAutoResetService.catchUpMissedExecutions();
+
     // 各APIエンドポイントを登録
     server.createContext("/hello", new HelloController()); // 動作確認用
 

--- a/src/main/java/com/habit/server/controller/TaskAutoResetController.java
+++ b/src/main/java/com/habit/server/controller/TaskAutoResetController.java
@@ -118,7 +118,7 @@ public class TaskAutoResetController {
             } else {
                 try {
                     // 指定チームのタスク自動再設定を実行
-                    taskAutoResetService.checkAndResetTasks(teamId);
+                    taskAutoResetService.checkAndResetTasks(teamId, java.time.LocalDate.now());
                     response = "チーム " + teamId + " のタスク自動再設定を実行しました";
                 } catch (Exception e) {
                     response = "エラーが発生しました: " + e.getMessage();

--- a/src/test/java/com/habit/server/service/TaskAutoResetServiceTest.java
+++ b/src/test/java/com/habit/server/service/TaskAutoResetServiceTest.java
@@ -79,7 +79,7 @@ class TaskAutoResetServiceTest {
 
         // --- When (実行) ---
         // チームAのタスクリセット処理を実行
-        int resetCount = taskAutoResetService.checkAndResetTasks(teamId);
+        int resetCount = taskAutoResetService.checkAndResetTasks(teamId, today);
 
         // --- Then (検証) ---
         assertEquals(1, resetCount, "1件のタスクが再設定されるはず");
@@ -113,7 +113,7 @@ class TaskAutoResetServiceTest {
         userTaskStatusRepository.save(yesterdayStatus);
 
         // --- When (実行) ---
-        int resetCount = taskAutoResetService.checkAndResetTasks(teamId);
+        int resetCount = taskAutoResetService.checkAndResetTasks(teamId, today);
 
         // --- Then (検証) ---
         assertEquals(1, resetCount, "1件のタスクが再設定されるはず");
@@ -149,7 +149,7 @@ class TaskAutoResetServiceTest {
         userTaskStatusRepository.save(user4_yesterday);
 
         // --- When (実行) ---
-        int resetCount = taskAutoResetService.checkAndResetTasks(teamId);
+        int resetCount = taskAutoResetService.checkAndResetTasks(teamId, today);
 
         // --- Then (検証) ---
         assertEquals(2, resetCount, "2ユーザー分のタスクが再設定されるはず");


### PR DESCRIPTION
### 概要


  サーバーが停止していた期間に実行されるべきだった日次のタスク自動更新が、サーバー再起動時にまとめて実行されるように改修しました。


  これにより、深夜メンテナンスなどでサーバーを長時間停止した場合でも、タスクの更新漏れが発生しなくなります。

 ###  変更点


   - サーバー起動時のタスク更新キャッチアップ処理の追加
       - 最後にタスク更新が成功した日時をlast_execution.logに記録するようにしました。
       - サーバー起動時にこのファイルを読み込み、未処理の日数分のタスク更新処理をまとめて実行するロジックをTaskAutoResetServiceに追加しました。
   - 手動更新APIの修正
       - TaskAutoResetControllerで、チームを指定して手動でタスクを更新する際に、現在日時を正しく渡すように修正しました。
   - `.gitignore`の更新
       - 自動生成されるlast_execution.logをGitの管理対象から除外しました。

  ### 影響範囲


   - タスクの自動更新機能
   - サーバー起動時の処理


  この変更による既存機能へのデグレードはありません。