### PR TITLE
ホーム画面の調整

### DIFF
--- a/src/main/resources/com/habit/client/gui/Home.fxml
+++ b/src/main/resources/com/habit/client/gui/Home.fxml
@@ -11,11 +11,14 @@
 <BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="350" prefWidth="600" stylesheets="@home.css" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.habit.client.HomeController">
     <left>
         <VBox alignment="CENTER" styleClass="vBox">
-            <Label fx:id="cheerMessageLabel" alignment="CENTER_LEFT" focusTraversable="false" maxWidth="-Infinity" minWidth="-Infinity" prefHeight="38.0" prefWidth="250.0" text="" wrapText="true">
+            <Label fx:id="cheerMessageLabel" alignment="CENTER_LEFT" focusTraversable="false" maxWidth="-Infinity" minWidth="-Infinity" prefHeight="60.0" prefWidth="250.0" wrapText="true">
             <VBox.margin>
                <Insets left="5.0" />
             </VBox.margin></Label>
-            <ImageView fx:id="characterView" fitHeight="120" fitWidth="120" />
+            <ImageView fx:id="characterView" fitHeight="120" fitWidth="120" styleClass="imageView">
+            <VBox.margin>
+               <Insets top="30.0" />
+            </VBox.margin></ImageView>
         </VBox>
     </left>
     <center>

--- a/src/main/resources/com/habit/client/gui/home.css
+++ b/src/main/resources/com/habit/client/gui/home.css
@@ -51,6 +51,22 @@
 
 }
 
+.list-view .scroll-bar {
+    -fx-background-color: transparent;
+}
+
+.list-view .scroll-bar .thumb {
+    -fx-background-color: #87cefa;
+    -fx-background-insets: 2;
+    -fx-background-radius: 10;
+}
+
+.list-view .scroll-bar .track {
+    -fx-background-color: #e0e0e0;
+    -fx-background-insets: 0;
+    -fx-background-radius: 10;
+}
+
 .label{
 	-fx-font-size: 14px;
 	-fx-background-color: #87cefa;
@@ -61,4 +77,3 @@
 	-fx-text-fil: #3a3a3a;
 	-fx-alignment: center;
 }
-


### PR DESCRIPTION
- 9つ以上のチームに所属したときにあらわれるスクロールバーの装飾
- キャラクタのメッセージが長い時に後半部分が切れてしまっていたためラベルのサイズを変更した.
- キャラクタの位置の調整.