### PR TITLE
未完了タスク表示の修正

### DIFF
--- a/src/main/java/com/habit/client/PersonalPageController.java
+++ b/src/main/java/com/habit/client/PersonalPageController.java
@@ -88,10 +88,7 @@ public class PersonalPageController {
             java.time.LocalDate dueDate = task.getDueDate();
             java.time.LocalDate today = LocalDate.now();
 
-            // 期限切れタスクは現在スキップする仕様
-            if (today.isAfter(dueDate)) {
-                continue; // Skip overdue tasks
-            }
+            
 
             Button tileBtn = new Button();
             tileBtn.setStyle("-fx-border-color: #aaa; -fx-padding: 30; -fx-background-color: #f9f9f9; -fx-min-width: 320px; -fx-min-height: 150px; -fx-alignment: center; -fx-font-size: 22px; -fx-font-weight: bold;");
@@ -189,12 +186,10 @@ public class PersonalPageController {
     private List<com.habit.domain.Task> fetchUserTasksForPersonalPage() {
         try {
             String sessionId = com.habit.client.LoginController.getSessionId();
-            java.time.LocalDate today = java.time.LocalDate.now();
             java.net.http.HttpClient client = java.net.http.HttpClient.newHttpClient();
             
-            // ★修正：getUserIncompleteTasksAPIを使用（このAPIは既に修正済み）
-            String url = "http://localhost:8080/getUserIncompleteTasks?teamID=" + java.net.URLEncoder.encode(teamID, "UTF-8")
-                       + "&date=" + today.toString();
+            // 新しいAPIを使用
+            String url = "http://localhost:8080/getIncompleteUserTaskStatus?teamID=" + java.net.URLEncoder.encode(teamID, "UTF-8");
             System.out.println("[PersonalPageController] Fetching user tasks from: " + url);
             
             java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()

--- a/src/main/java/com/habit/client/TeamTopController.java
+++ b/src/main/java/com/habit/client/TeamTopController.java
@@ -344,11 +344,9 @@ public class TeamTopController {
                     return;
                 }
                 String sessionId = LoginController.getSessionId();
-                java.time.LocalDate today = java.time.LocalDate.now();
                 HttpClient client = HttpClient.newHttpClient();
-                // PersonalPageと同じAPIを使用
-                String url = "http://localhost:8080/getUserIncompleteTasks?teamID=" + URLEncoder.encode(teamID, "UTF-8")
-                           + "&date=" + today.toString();
+                // 新しいAPIを呼び出す
+                String url = "http://localhost:8080/getIncompleteUserTaskStatus?teamID=" + URLEncoder.encode(teamID, "UTF-8");
                 HttpRequest request = HttpRequest.newBuilder()
                         .uri(URI.create(url))
                         .timeout(java.time.Duration.ofSeconds(10))
@@ -356,7 +354,7 @@ public class TeamTopController {
                         .GET()
                         .build();
                 HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-                // レスポンスは [{"taskId":"...","taskName":"...","dueDate":"..."}] のJSON配列
+                // レスポンスは [{"taskId":"...","taskName":"...","dueDate":"...","isDone":false}] のJSON配列
                 java.util.List<String> taskNames = new java.util.ArrayList<>();
                 String json = response.body();
                 System.out.println("[TeamTopController] API response: " + json);
@@ -365,19 +363,7 @@ public class TeamTopController {
                     for (int i = 0; i < arr.length(); i++) {
                         org.json.JSONObject obj = arr.getJSONObject(i);
                         String taskName = obj.optString("taskName", null);
-                        String dueDateStr = obj.optString("dueDate", null);
-                        java.time.LocalDate dueDate = null;
-                        if (dueDateStr != null && !dueDateStr.isEmpty() && !"null".equals(dueDateStr)) {
-                            try {
-                                dueDate = java.time.LocalDate.parse(dueDateStr);
-                            } catch (Exception ignore) {}
-                        }
-                        
-                        // PersonalPageと同じ条件：期限切れタスクはスキップ
                         if (taskName != null) {
-                            if (dueDate != null && today.isAfter(dueDate)) {
-                                continue; // Skip overdue tasks
-                            }
                             taskNames.add(taskName);
                         }
                     }
@@ -453,10 +439,9 @@ public class TeamTopController {
                 return new java.util.ArrayList<>();
             }
             String sessionId = LoginController.getSessionId();
-            java.time.LocalDate today = java.time.LocalDate.now();
             HttpClient client = HttpClient.newHttpClient();
-            String url = "http://localhost:8080/getUserIncompleteTasks?teamID=" + URLEncoder.encode(teamID, "UTF-8")
-                       + "&date=" + today.toString();
+            // 新しいAPIを呼び出す
+            String url = "http://localhost:8080/getIncompleteUserTaskStatus?teamID=" + URLEncoder.encode(teamID, "UTF-8");
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
                     .timeout(java.time.Duration.ofSeconds(10))

--- a/src/main/java/com/habit/server/HabitServer.java
+++ b/src/main/java/com/habit/server/HabitServer.java
@@ -58,7 +58,7 @@ public class HabitServer {
       new UserTaskStatusController(authService, userTaskStatusRepository);
 
   // タスク自動再設定関連コンポーネント
-  // スケジューラー: 1時間ごとの自動実行を担当
+  // スケジューラー: 自動実行を担当
   private static TaskAutoResetService taskAutoResetService;
   private static TaskAutoResetScheduler taskAutoResetScheduler;
   
@@ -136,6 +136,10 @@ public class HabitServer {
     server.createContext(
         "/getUserIncompleteTasks",
         userTaskStatusController.getUserIncompleteTasksHandler(authService));
+    // ユーザーの未完了タスク(isDone=false, dueDate > now)一覧取得API
+    server.createContext(
+        "/getIncompleteUserTaskStatus",
+        userTaskStatusController.getIncompleteUserTaskStatusHandler(authService));
     // チーム全員分のタスク進捗一覧API
     server.createContext(
         "/getTeamTaskStatusList",
@@ -179,7 +183,7 @@ public class HabitServer {
     server.setExecutor(null);
     server.start();
 
-    // 1時間ごとの自動実行スケジューラーを開始
+    // 自動実行スケジューラーを開始
     taskAutoResetScheduler.start();
 
     // サーバーシャットダウン時の処理を登録
@@ -193,7 +197,7 @@ public class HabitServer {
 
     System.out.println("サーバが起動しました: http://localhost:8080/hello");
     System.out.println(
-        "タスク自動再設定機能が有効になりました（1時間ごと実行）");
+        "タスク自動再設定機能が有効になりました");
     System.out.println(
         "手動実行API: /manualTaskReset, /manualTaskResetTeam?teamId=xxx");
   }

--- a/src/main/java/com/habit/server/repository/UserTaskStatusRepository.java
+++ b/src/main/java/com/habit/server/repository/UserTaskStatusRepository.java
@@ -65,6 +65,28 @@ public class UserTaskStatusRepository {
         }
         return result;
     }
+    // ユーザID・チームIDで検索
+    public List<UserTaskStatus> findByUserIdAndTeamId(String userId, String teamId) {
+        List<UserTaskStatus> result = new ArrayList<>();
+        try (Connection conn = DriverManager.getConnection(dbUrl)) {
+            String sql = "SELECT uts.* FROM user_task_statuses uts " +
+                         "JOIN tasks t ON uts.taskId = t.taskId " +
+                         "WHERE uts.userId = ? AND t.teamID = ?";
+            try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
+                pstmt.setString(1, userId);
+                pstmt.setString(2, teamId);
+                ResultSet rs = pstmt.executeQuery();
+                while (rs.next()) {
+                    UserTaskStatus status = mapRowToStatus(rs);
+                    result.add(status);
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return result;
+    }
+
     // userIdとteamIdで、そのユーザーが担当するチーム内タスクID一覧を取得
     public List<String> findTaskIdsByUserIdAndTeamId(String userId, String teamId) {
         List<String> result = new ArrayList<>();

--- a/src/main/java/com/habit/server/scheduler/TaskAutoResetScheduler.java
+++ b/src/main/java/com/habit/server/scheduler/TaskAutoResetScheduler.java
@@ -14,7 +14,6 @@ import java.time.temporal.ChronoUnit;
 /**
  * タスク自動再設定の定期実行スケジューラー
  *  タスクの自動再設定を定期的に実行する。
- *  1分ごとに実行
  * 期限切れタスクの検出が目的
  */
 public class TaskAutoResetScheduler {

--- a/src/main/java/com/habit/server/service/TaskAutoResetService.java
+++ b/src/main/java/com/habit/server/service/TaskAutoResetService.java
@@ -25,7 +25,6 @@ import java.util.stream.Collectors;
 /**
  * タスクの自動再設定サービス
  *  タスクが期限を過ぎても未完了の場合、次回サイクルのタスクを自動生成
- *  1分ごとに自動実行（TaskAutoResetSchedulerによる）
  *  手動実行も可能（TaskAutoResetControllerのAPI経由）
  *  既に同じ日付のタスクが存在する場合は重複作成しない
  */
@@ -38,7 +37,7 @@ public class TaskAutoResetService {
     private static final Path LAST_EXECUTION_FILE = Paths.get("last_execution.log");
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
     
-    // 重複実行防止用のフラグ（1分ごと実行のため、処理が重複しないよう制御）
+    // 重複実行防止用のフラグ
     private volatile boolean isRunning = false;
 
     // システムメッセージ用の固定ユーザー


### PR DESCRIPTION
## feat: 未完了タスク取得APIの改善とクライアント側の対応

### 概要
  期限が今より後で、かつ未完了のUserTaskStatusをユーザーに応じて正しく取得できるよう、タスク取得APIのロジックを改善しました。これにより、クライアント側でのタスク表示が正常になることが期待されます。

### 変更点
   1. `UserTaskStatusRepository.java`:
       * findByUserIdAndTeamId メソッドを追加しました。これにより、特定のユーザーとチームに紐づくUserTaskStatusを効率的に取得できるようになりました。


   2. `UserTaskStatusController.java`:
       * 新しいAPIハンドラ GetIncompleteUserTaskStatusHandler を追加しました。
       * このハンドラは /getIncompleteUserTaskStatus エンドポイントを提供し、ユーザーIDとチームIDに基づいて、isDone が false かつ dueDate が現在時刻より後のタスクのみを返します。
       * ログ出力を調整し、API呼び出し時のメッセージをコメントアウトし、最終的なレスポンス内容を出力するように変更しました。

   3. `HabitServer.java`:
       * 新しいAPIエンドポイント /getIncompleteUserTaskStatus を登録しました。


   4. `TeamTopController.java`:
       * loadTeamTasksAndUserTasks および getUserTasksForPersonalPage メソッドにおいて、タスク取得APIを /getUserIncompleteTasks から新しく作成した /getIncompleteUserTaskStatus
         に変更しました。
       * サーバー側でフィルタリングが行われるため、クライアント側での期限切れタスクのスキップロジックを削除しました。


   5. `PersonalPageController.java`:
       * fetchUserTasksForPersonalPage メソッドにおいて、タスク取得APIを /getUserIncompleteTasks から /getIncompleteUserTaskStatus に変更しました。
       * updateTaskTiles メソッドから、期限切れタスクのスキップロジックを削除しました。

  影響範囲
   * タスク表示を行う TeamTopController および PersonalPageController のタスクリスト表示ロジックが変更されます。
   * サーバー側のAPIエンドポイントが追加されます。


  テスト方法
   * アプリケーションを起動し、ログイン後、チームトップ画面および個人ページで表示されるタスクが、未完了かつ期限が今日以降のもののみであることを確認してください。
   * タスクを完了した際に、リストから正しく消えることを確認してください。