### PR TITLE
サボりランキング実装

### DIFF
--- a/src/main/java/com/habit/server/HabitServer.java
+++ b/src/main/java/com/habit/server/HabitServer.java
@@ -121,6 +121,9 @@ public class HabitServer {
         "/getSabotagePoints",
         userController.getSabotagePointsHandler()); // サボりポイント取得
     server.createContext(
+        "/updateSabotagePoints",
+        userController.getUpdateSabotagePointsHandler()); // サボりポイント更新（テスト用）
+    server.createContext(
         "/getUserTaskIds",
         userTaskStatusController
             .getGetUserTaskIdsHandler()); // UserTaskStatusからTaskId取得
@@ -171,6 +174,9 @@ public class HabitServer {
     server.createContext(
         "/getTeamTasks",
         teamController.getGetTeamTasksHandler()); // チームタスク一覧
+    server.createContext(
+        "/getTeamSabotageRanking",
+        teamController.getGetTeamSabotageRankingHandler()); // チーム内サボりランキング
     
     // チーム共通タスク管理API
     server.createContext(

--- a/src/main/java/com/habit/server/controller/UserTaskStatusController.java
+++ b/src/main/java/com/habit/server/controller/UserTaskStatusController.java
@@ -389,6 +389,23 @@ public class UserTaskStatusController {
                     // タスク完了ステータスを更新(保存)
                     status.setDone(true);
                     repo.save(status);
+                    
+                    // タスク完了時にサボりポイントを即座に減らす
+                    try {
+                        com.habit.server.repository.UserRepository userRepo = new com.habit.server.repository.UserRepository();
+                        com.habit.domain.User user = userRepo.findById(userId[0]);
+                        if (user != null) {
+                            int currentPoints = user.getSabotagePoints();
+                            int newPoints = Math.max(0, currentPoints - 1); // 0未満にはしない
+                            user.setSabotagePoints(newPoints);
+                            userRepo.save(user);
+                            System.out.println("タスク完了によりサボりポイント更新: " + user.getUsername() + " " + currentPoints + "pt → " + newPoints + "pt");
+                        }
+                    } catch (Exception e) {
+                        System.err.println("サボりポイント更新エラー: " + e.getMessage());
+                        e.printStackTrace();
+                    }
+                    
                     response = "タスク完了: userId=" + userId[0] + ", taskId=" + taskId[0] + ", date=" + dateStr;
                 } else {
                     response = "パラメータが不正です";

--- a/src/main/resources/com/habit/client/gui/TeamTop.fxml
+++ b/src/main/resources/com/habit/client/gui/TeamTop.fxml
@@ -16,26 +16,40 @@
         </HBox>
     </top>
     <center>
-        <VBox spacing="10">
-            <TableView fx:id="taskTable" prefHeight="470"/>
-            <HBox spacing="20">
-                <VBox>
-                    <Label text="本日の未消化タスク一覧"/>
-                    <ListView fx:id="todayTaskList" prefHeight="120" prefWidth="360"/>
+        <HBox spacing="20">
+            <!-- 左側: ランキング、キャラクター表示領域 -->
+            <VBox spacing="10" prefWidth="300">
+                <!-- サボりランキング -->
+                <VBox spacing="5">
+                    <Label text="🏆 チーム内サボりランキング" style="-fx-font-size: 16px; -fx-font-weight: bold; -fx-text-fill: #d32f2f;"/>
+                    <ListView fx:id="sabotageRankingList" prefHeight="120" style="-fx-background-color: #fff3f3; -fx-border-color: #ffcdd2; -fx-border-radius: 5;"/>
                 </VBox>
-                <VBox>
-                    <Label text="チームチャット"/>
-                    <ListView fx:id="chatList" prefHeight="90" prefWidth="300"/>
+                
+                <!-- キャラクターとメッセージ -->
+                <VBox alignment="CENTER" spacing="10">
+                    <Label fx:id="cheerMessageLabel" text="" style="-fx-font-size: 16px; -fx-background-color: #fffbe7; -fx-border-color: #cccccc; -fx-border-radius: 10; -fx-background-radius: 10; -fx-padding: 10; -fx-text-fill: #3a3a3a;" wrapText="true" maxWidth="280" alignment="CENTER"/>
+                    <ImageView fx:id="teamCharView" fitWidth="200" fitHeight="200" preserveRatio="true"/>
                 </VBox>
-            </HBox>
-        </VBox>
+            </VBox>
+            
+            <!-- 右側: タスク表とその他の要素 -->
+            <VBox spacing="10" prefWidth="580">
+                <TableView fx:id="taskTable" prefHeight="350"/>
+                <HBox spacing="20">
+                    <VBox>
+                        <Label text="本日の未消化タスク一覧"/>
+                        <ListView fx:id="todayTaskList" prefHeight="120" prefWidth="280"/>
+                    </VBox>
+                    <VBox>
+                        <Label text="チームチャット"/>
+                        <ListView fx:id="chatList" prefHeight="90" prefWidth="280"/>
+                    </VBox>
+                </HBox>
+            </VBox>
+        </HBox>
     </center>
     <bottom>
     </bottom>
     <left>
-        <VBox alignment="BOTTOM_LEFT">
-            <Label fx:id="cheerMessageLabel" text="" style="-fx-font-size: 14px; -fx-background-color: #fffbe7; -fx-border-color: #cccccc; -fx-border-radius: 10; -fx-background-radius: 10; -fx-padding: 8; -fx-text-fill: #3a3a3a;" wrapText="true" maxWidth="250" alignment="CENTER_LEFT"/>
-            <ImageView fx:id="teamCharView" fitWidth="100" fitHeight="100"/>
-        </VBox>
     </left>
 </BorderPane>


### PR DESCRIPTION
このプルリクエストでは、チームメンバー向けの「サボタージュランキング」を表示する新機能を導入し、この機能をサポートするためのサーバーサイドとクライアントサイドの変更が含まれています。主な更新内容には、UIにランキングリストの追加、サボタージュポイントの取得と更新のための新しいサーバーエンドポイント、タスクの完了状況に基づいてランキングを動的に更新するロジックが含まれます。

### クライアントサイドの変更:
* **UI更新**: `TeamTop.fxml`レイアウトにサボタージュランキングを表示するための`ListView`を追加し、スタイリングとランキングおよびキャラクター表示用の新しいセクションを追加しました。
* **コントローラーの強化**: 
  - `TeamTopController`に`sabotageRankingList`フィールドと`loadSabotageRanking`メソッドを追加し、サーバーからサボタージュランキングを取得して表示する機能を追加しました。[[1]](diffhunk://#diff-4768973945ad3df15c55650a00dd13c0958a8ed13bdfb87c889a851ad2cd0263R60-R62) [[2]](diffhunk://# diff-4768973945ad3df15c55650a00dd13c0958a8ed13bdfb87c889a851ad2cd0263R771-R864)
  - `refreshSabotageRanking` メソッドを導入し、ランキングの外部再読み込みを可能にしました。

### サーバー側の変更:
* **新しいエンドポイント**:
  - `TeamController` に `/getTeamSabotageRanking` エンドポイントを追加し、チームのサボタージュランキングを取得できるようにしました。[[1]](diffhunk://#diff-379852c2ee18f9496c98c69d774ced41ebb4610b72f59afbcef4e4dc57b277f2R177-R179) [[2]](diffhunk://# diff-379051c9e10a468b071d14c3c1ba4c1047868bc664b11fcd6fd8f288b1a5b499R425-R492)
  - `UserController`に`/updateSabotagePoints`エンドポイントを追加し、サボタージュポイントの更新テストを実施しました。[[1]](diffhunk://#diff-379852c2ee18f9496c98c69d774ced41ebb4610b72f59afbcef4e4dc57b277f2R123-R125) [[2]](diffhunk://# diff-178cafd8adcfb6eb4bf3ddee3421fea8908f5a4e1a60228978861ef68dc51e75R92-R147)
* **タスク完了ロジック**: `UserTaskStatusController` を更新し、タスクが完了としてマークされた際に即座にサボタージュポイントを減少させるようにしました。

これらの変更は、可視的でインタラクティブなランキングシステムを提供することでアプリケーションを強化し、チームメンバーが積極的に参加し生産性を維持するよう促します。