### PR TITLE
メッセージ削除機能の追加

### DIFF
--- a/src/main/java/com/habit/client/ChatController.java
+++ b/src/main/java/com/habit/client/ChatController.java
@@ -94,14 +94,37 @@ public class ChatController {
       teamNameLabel.setText(teamName);
     }
 
-    // ListViewのセルファクトリを設定
+    // ListViewのセルファリを設定
     chatList.setCellFactory(lv -> new ListCell<Message>() {
+      private final ContextMenu contextMenu = new ContextMenu();
+      private final MenuItem deleteItem = new MenuItem("削除");
+
+      {
+        deleteItem.setOnAction(event -> {
+          Message selectedMessage = getItem();
+          if (selectedMessage != null) {
+            Alert alert = new Alert(Alert.AlertType.CONFIRMATION);
+            alert.setTitle("確認");
+            alert.setHeaderText("メッセージの削除");
+            alert.setContentText("本当にこのメッセージを削除しますか？");
+
+            Optional<ButtonType> result = alert.showAndWait();
+            if (result.isPresent() && result.get() == ButtonType.OK) {
+              deleteChatMessage(selectedMessage.getMessageId());
+            }
+          }
+        });
+        contextMenu.getItems().add(deleteItem);
+      }
+
       @Override
       protected void updateItem(Message message, boolean empty) {
         super.updateItem(message, empty);
         if (empty || message == null) {
           setText(null);
+          setContextMenu(null);
         } else {
+          // メッセージのテキストを設定
           final String formatPattern = "yyyy-MM-dd HH:mm:ss";
           StringBuilder sb = new StringBuilder();
           sb.append("[" +
@@ -111,33 +134,16 @@ public class ChatController {
           sb.append("[" + message.getSender().getUsername() + "]");
           sb.append(": " + message.getContent());
           setText(sb.toString());
+
+          // 自分のメッセージの場合のみContextMenuを設定
+          if (message.getSender().getUserId().equals(userId)) {
+            setContextMenu(contextMenu);
+          } else {
+            setContextMenu(null);
+          }
         }
       }
     });
-
-    // ContextMenuの作成
-    // 右クリックでメッセージを削除できるようにする
-    ContextMenu contextMenu = new ContextMenu();
-    MenuItem deleteItem = new MenuItem("削除");
-    deleteItem.setOnAction(event -> {
-      Message selectedMessage = chatList.getSelectionModel().getSelectedItem();
-      // 確認ダイアログを表示
-      if (selectedMessage != null) {
-        Alert alert = new Alert(Alert.AlertType.CONFIRMATION);
-        alert.setTitle("確認");
-        alert.setHeaderText("メッセージの削除");
-        alert.setContentText("本当にこのメッセージを削除しますか？");
-
-        Optional<ButtonType> result = alert.showAndWait();
-        if (result.isPresent() && result.get() == ButtonType.OK) {
-          deleteChatMessage(selectedMessage.getMessageId());
-        }
-      }
-    });
-    contextMenu.getItems().add(deleteItem);
-
-    // ListViewにContextMenuを設定
-    chatList.setContextMenu(contextMenu);
 
     // チャット送信ボタンのアクション設定
     btnSend.setOnAction(unused -> {

--- a/src/main/java/com/habit/server/HabitServer.java
+++ b/src/main/java/com/habit/server/HabitServer.java
@@ -126,6 +126,8 @@ public class HabitServer {
     server.createContext(
         "/getChatLog",
         messageController.getGetChatLogHandler()); // チャット履歴取得
+    server.createContext("/deleteChatMessage",
+        messageController.getDeleteChatMessageHandler()); // チャット削除
     server.createContext(
         "/getJoinedTeamInfo",
         userController.getGetJoinedTeamInfoHandler()); // 参加チーム取得

--- a/src/main/java/com/habit/server/repository/MessageRepository.java
+++ b/src/main/java/com/habit/server/repository/MessageRepository.java
@@ -87,4 +87,18 @@ public class MessageRepository {
     }
     return messages;
   }
+
+  /**
+   * 削除メソッド。
+   */
+  public void delete(String messageId) {
+    String sql = "DELETE FROM messages WHERE message_id = ?";
+    try (Connection conn = DriverManager.getConnection(databaseUrl);
+        PreparedStatement pstmt = conn.prepareStatement(sql)) {
+      pstmt.setString(1, messageId);
+      pstmt.executeUpdate();
+    } catch (SQLException e) {
+      logger.error("Error deleting message: {}", e.getMessage(), e);
+    }
+  }
 }


### PR DESCRIPTION
本プルリクエストでは、チャット機能において、ユーザーが自身で投稿したメッセージを削除できる機能を追加しました。

### 主な変更点
   - サーバーサイド
       - MessageRepository に delete メソッドを追加し、データベースからメッセージを物理削除できるようにしました。
       - MessageController に /deleteChatMessage エンドポイント (DELETE) を追加し、メッセージIDを指定して削除を実行できるようにAPIを公開しました。
       - HabitServer に上記エンドポイントのルーティングを追加しました。
   - クライアントサイド
       - 削除権限の制御: 自分が送信したメッセージにのみ、右クリックで「削除」メニューが表示されるようにしました。他人のメッセージにはメニューが表示されません。
       - UIの改善: チャットの ListView を右クリックすると表示されるコンテキストメニューに「削除」項目を追加しました。
       - 誤操作防止: 「削除」を実行する前に、確認ダイアログを表示するようにしました。
       - 表示の同期: メッセージ削除後は、チャットログを自動的に再読み込みし、UIに反映します。

  確認方法
   1. アプリケーションを起動し、いずれかのチームのチャット画面を開きます。
   2. 自分が送信したメッセージを右クリックし、コンテキストメニューから「削除」を選択します。
   3. 確認ダイアログが表示されることを確認します。
   4. 「OK」をクリックするとメッセージが削除され、チャットログから消えることを確認します。
   5. 他人が送信したメッセージを右クリックし、コンテキストメニューが表示されないことを確認します。

  ご確認のほど、よろしくお願いいたします。