### PR TITLE
週次タスクのUserTaskStatus初期日付を正しく設定

### DIFF
--- a/src/main/java/com/habit/server/repository/TaskRepository.java
+++ b/src/main/java/com/habit/server/repository/TaskRepository.java
@@ -255,4 +255,31 @@ public class TaskRepository {
     }
     return list;
   }
+
+  /*
+   * タスクIDでタスクを取得
+   */
+  public Task findById(String taskId) {
+    try (Connection conn = DriverManager.getConnection(databaseUrl)) {
+      String sql = "SELECT * FROM tasks WHERE taskId = ?";
+      try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
+        pstmt.setString(1, taskId);
+        ResultSet rs = pstmt.executeQuery();
+        if (rs.next()) {
+          Task task = new Task(
+              rs.getString("taskId"), rs.getString("taskName"),
+              rs.getString("description"), 
+              rs.getString("teamID"),
+              rs.getString("dueDate") != null
+                  ? java.time.LocalDate.parse(rs.getString("dueDate"))
+                  : null,
+              rs.getString("cycleType"));
+          return task;
+        }
+      }
+    } catch (SQLException e) {
+      e.printStackTrace();
+    }
+    return null;
+  }
 }

--- a/src/main/java/com/habit/server/service/TeamTaskService.java
+++ b/src/main/java/com/habit/server/service/TeamTaskService.java
@@ -61,11 +61,15 @@ public class TeamTaskService {
                 memberId, task.getTaskId(), today).isPresent();
 
             if (!existsByTaskId) {
+                LocalDate targetDate = today;
+                if ("weekly".equals(task.getCycleType())) {
+                    targetDate = today.plusWeeks(1);
+                }
                 UserTaskStatus newStatus = new UserTaskStatus(
                     memberId,
                     task.getTaskId(),
                     task.getTeamId(),
-                    today,
+                    targetDate,
                     false
                 );
                 userTaskStatusRepository.save(newStatus);
@@ -92,15 +96,19 @@ public class TeamTaskService {
                 newMemberId, task.getTaskId(), today).isPresent();
 
             if (!existsByTaskId) {
+                LocalDate targetDate = today;
+                if ("weekly".equals(task.getCycleType())) {
+                    targetDate = today.plusWeeks(1);
+                }
                 UserTaskStatus newStatus = new UserTaskStatus(
                     newMemberId,
                     task.getTaskId(),
                     teamId,
-                        today,
-                        false
-                    );
-                    userTaskStatusRepository.save(newStatus);
-                }
+                    targetDate,
+                    false
+                );
+                userTaskStatusRepository.save(newStatus);
+            }
             
         }
     }


### PR DESCRIPTION
## 週次タスクのUserTaskStatus初期日付を正しく設定

### 概要
  本変更は、週次タスク（cycleTypeがweekly）のUserTaskStatusが作成される際に、その日付(date)が正しく翌週に設
  定されるように修正します。

### 変更内容
   - src/main/java/com/habit/server/service/TeamTaskService.java 内の以下のメソッドを修正しました。
       - createUserTaskStatusForAllMembers(Task task)
       - createUserTaskStatusForNewMember(String teamId, String newMemberId)

  これらのメソッドにおいて、UserTaskStatusを新規作成する際に、対象のタスクのcycleTypeがweeklyである場
  合、UserTaskStatusのdateフィールドを現在の日付から7日後に設定するように変更しました。dailyタスクやそ
  の他の場合は、従来通り現在の日付が設定されます。

### 変更の理由
  これまでの実装では、週次タスクが新規作成された際、または新しいメンバーがチームに参加した際に、そのタ
  スクのUserTaskStatusの日付が常に現在の日付に設定されていました。これにより、週次タスクの初回消化日が
  誤って当日になってしまう問題がありました。

  本修正により、週次タスクのUserTaskStatusが正しく翌週の日付で初期化され、タスクのサイクル管理がより正
  確になります。