### PR TITLE
Fix task reset

### DIFF
--- a/src/main/java/com/habit/client/TeamTopController.java
+++ b/src/main/java/com/habit/client/TeamTopController.java
@@ -783,9 +783,10 @@ public class TeamTopController {
           taskNameMap.put(taskId, taskName);
         }
 
-        // 進捗一覧取得（全メンバー×タスク×過去7日）
-        String date = java.time.LocalDate.now().toString();
-        int days = 7;
+        // 進捗一覧取得（全メンバー×タスク×過去7日と将来7日）
+        // 今日から7日後をdateに設定し、daysを15日間にすることで、過去7日＋今日＋将来7日の計15日間のデータを取得する
+        String date = java.time.LocalDate.now().plusDays(7).toString();
+        int days = 15;
         String statusUrl = Config.getServerUrl() +
                            "/getTeamTaskStatusList?teamID=" +
                            URLEncoder.encode(teamID, "UTF-8") +

--- a/src/main/java/com/habit/server/controller/UserTaskStatusController.java
+++ b/src/main/java/com/habit/server/controller/UserTaskStatusController.java
@@ -381,7 +381,7 @@ public class UserTaskStatusController {
                     com.habit.server.repository.TaskRepository taskRepo = new com.habit.server.repository.TaskRepository();
                     
                     // 既存のステータスがなければエラーを返す
-                    java.util.Optional<com.habit.domain.UserTaskStatus> optStatus = repo.findByUserIdAndTaskIdAndDate(userId[0], taskId[0], date);
+                    java.util.Optional<com.habit.domain.UserTaskStatus> optStatus = repo.findUpcomingIncompleteByUserIdAndTaskId(userId[0], taskId[0]);
                     if (optStatus.isEmpty()) {
                         response = "エラー: 該当のタスクステータスが見つかりません。";
                         exchange.getResponseHeaders().set("Content-Type", "text/plain; charset=UTF-8");

--- a/src/main/java/com/habit/server/repository/TaskRepository.java
+++ b/src/main/java/com/habit/server/repository/TaskRepository.java
@@ -255,4 +255,31 @@ public class TaskRepository {
     }
     return list;
   }
+
+  /*
+   * タスクIDでタスクを取得
+   */
+  public Task findById(String taskId) {
+    try (Connection conn = DriverManager.getConnection(databaseUrl)) {
+      String sql = "SELECT * FROM tasks WHERE taskId = ?";
+      try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
+        pstmt.setString(1, taskId);
+        ResultSet rs = pstmt.executeQuery();
+        if (rs.next()) {
+          Task task = new Task(
+              rs.getString("taskId"), rs.getString("taskName"),
+              rs.getString("description"), 
+              rs.getString("teamID"),
+              rs.getString("dueDate") != null
+                  ? java.time.LocalDate.parse(rs.getString("dueDate"))
+                  : null,
+              rs.getString("cycleType"));
+          return task;
+        }
+      }
+    } catch (SQLException e) {
+      e.printStackTrace();
+    }
+    return null;
+  }
 }

--- a/src/main/java/com/habit/server/service/TaskAutoResetService.java
+++ b/src/main/java/com/habit/server/service/TaskAutoResetService.java
@@ -185,8 +185,14 @@ public class TaskAutoResetService {
             logger.info("[DEBUG] 新しい期限日: " + newDueDate);
 
             // Task自体のdueDateを更新して保存
-            task.setDueDate(newDueDate);
-            taskRepository.save(task);
+            // ただし、現在のdueDateがnewDueDateよりも将来の場合は書き換えない
+            // つまり、newDueDateが現在のdueDateと同じかそれより後の日付の場合にのみ更新
+            if (task.getDueDate() == null || !newDueDate.isBefore(task.getDueDate())) {
+                task.setDueDate(newDueDate);
+                taskRepository.save(task);
+            } else {
+                logger.info("[DEBUG] タスクのdueDateは将来のため更新をスキップ: " + task.getTaskName() + " (現在のdueDate: " + task.getDueDate() + ", 計算されたdueDate: " + newDueDate + ")");
+            }
 
             // 昨日の日付でUserTaskStatusを検索
             List<UserTaskStatus> statusesToCheck = userTaskStatusRepository.findByTaskIdAndDate(task.getTaskId(), dateToCheck);

--- a/src/main/java/com/habit/server/service/TeamTaskService.java
+++ b/src/main/java/com/habit/server/service/TeamTaskService.java
@@ -61,11 +61,15 @@ public class TeamTaskService {
                 memberId, task.getTaskId(), today).isPresent();
 
             if (!existsByTaskId) {
+                LocalDate targetDate = today;
+                if ("weekly".equals(task.getCycleType())) {
+                    targetDate = today.plusWeeks(1);
+                }
                 UserTaskStatus newStatus = new UserTaskStatus(
                     memberId,
                     task.getTaskId(),
                     task.getTeamId(),
-                    today,
+                    targetDate,
                     false
                 );
                 userTaskStatusRepository.save(newStatus);
@@ -92,15 +96,19 @@ public class TeamTaskService {
                 newMemberId, task.getTaskId(), today).isPresent();
 
             if (!existsByTaskId) {
+                LocalDate targetDate = today;
+                if ("weekly".equals(task.getCycleType())) {
+                    targetDate = today.plusWeeks(1);
+                }
                 UserTaskStatus newStatus = new UserTaskStatus(
                     newMemberId,
                     task.getTaskId(),
                     teamId,
-                        today,
-                        false
-                    );
-                    userTaskStatusRepository.save(newStatus);
-                }
+                    targetDate,
+                    false
+                );
+                userTaskStatusRepository.save(newStatus);
+            }
             
         }
     }

--- a/src/main/java/com/habit/server/service/TeamTaskService.java
+++ b/src/main/java/com/habit/server/service/TeamTaskService.java
@@ -61,15 +61,11 @@ public class TeamTaskService {
                 memberId, task.getTaskId(), today).isPresent();
 
             if (!existsByTaskId) {
-                LocalDate targetDate = today;
-                if ("weekly".equals(task.getCycleType())) {
-                    targetDate = today.plusWeeks(1);
-                }
                 UserTaskStatus newStatus = new UserTaskStatus(
                     memberId,
                     task.getTaskId(),
                     task.getTeamId(),
-                    targetDate,
+                    task.getDueDate(), // タスクのdueDateをそのまま使用
                     false
                 );
                 userTaskStatusRepository.save(newStatus);
@@ -96,15 +92,11 @@ public class TeamTaskService {
                 newMemberId, task.getTaskId(), today).isPresent();
 
             if (!existsByTaskId) {
-                LocalDate targetDate = today;
-                if ("weekly".equals(task.getCycleType())) {
-                    targetDate = today.plusWeeks(1);
-                }
                 UserTaskStatus newStatus = new UserTaskStatus(
                     newMemberId,
                     task.getTaskId(),
                     teamId,
-                    targetDate,
+                    task.getDueDate(), // タスクのdueDateをそのまま使用
                     false
                 );
                 userTaskStatusRepository.save(newStatus);


### PR DESCRIPTION
## feat: 週次タスクのUserTaskStatus初期日付、タスク完了処理、およびタスクリセット時のdueDate更新ロジックの改善

### 概要
  本変更は、週次タスクのUserTaskStatusが作成される際の日付設定を修正し、それに伴うタスク完了処理の対応、お
  よびタスク自動リセット時にTaskインスタンスのdueDateが意図せず上書きされる可能性を排除するものです。これ
  により、タスク管理の正確性と堅牢性が向上します。

### 変更内容
   1. 週次タスクの`UserTaskStatus`初期日付設定の修正:
       - 対象ファイル: src/main/java/com/habit/server/service/TeamTaskService.java
       - 修正メソッド:
           - createUserTaskStatusForAllMembers(Task task)
           - createUserTaskStatusForNewMember(String teamId, String newMemberId)
       - 変更点: 以前はcycleTypeに基づいてUserTaskStatusのdateを計算していましたが、タスク作成時にユーザーが
         入力したTaskオブジェクトのdueDateを直接UserTaskStatusのdateとして使用するように変更しました。これに
         より、ユーザーが設定したタスクの期限がUserTaskStatusに正確に反映されます。

   2. タスク完了処理の修正:
       - 対象ファイル:
           - src/main/java/com/habit/server/repository/UserTaskStatusRepository.java
           - src/main/java/com/habit/server/controller/UserTaskStatusController.java
       - 追加メソッド: UserTaskStatusRepositoryにfindUpcomingIncompleteByUserIdAndTaskId(String userId,
         String taskId)メソッドを追加しました。
           - このメソッドは、指定されたuserIdとtaskIdに対し、本日以降で最も日付が近く、かつ未完了（isDone =
             0）のUserTaskStatusを検索して返します。
       - 修正メソッド: UserTaskStatusController内のCompleteUserTaskHandler
       - 変更点: タスク完了時にUserTaskStatusを検索する際、厳密な日付一致ではなく、上記で追加したfindUpcomin
         gIncompleteByUserIdAndTaskIdメソッドを使用するように変更しました。これにより、週次タスクのように将
         来の日付で登録されたUserTaskStatusも正しく見つけ出し、完了処理を行うことができるようになります。

   3. タスクリセット時の`Task`の`dueDate`更新ロジックの改善:
       - 対象ファイル: src/main/java/com/habit/server/service/TaskAutoResetService.java
       - 修正メソッド: checkAndResetTasks(String teamId, LocalDate executionDate)
       - 変更点: TaskインスタンスのdueDateを更新する際に、計算されたnewDueDateが現在のTaskのdueDateよりも過
         去の日付になる場合は書き換えないように条件を追加しました。具体的には、newDueDateが現在のdueDateと同
         じかそれより後の日付の場合にのみTaskのdueDateを更新するようにしました。
       - 影響範囲: checkAndReportTasksForTodayメソッドはデバッグ用途であり、TaskのdueDateを直接更新するロジ
         ックは含まれていないため、この変更の影響はありません。

### 変更の理由
   1. `UserTaskStatus`日付の正確性向上:
      ユーザーがタスク作成時に入力したdueDateがUserTaskStatusに直接反映されることで、タスクの期限管理がよ
  り直感的かつ正確になります。特に週次タスクにおいて、初回期限が正しく設定されるようになります。

   2. 週次タスクの完了処理の対応:
      UserTaskStatusが将来の日付で作成されるようになったため、従来の完了処理ロジックでは該当するステータス
  を見つけられない問題がありました。新しい検索メソッドとそれを利用したCompleteUserTaskHandlerの修正により
  、週次タスクの完了処理が正しく機能するようになります。

   3. `Task`の`dueDate`の意図しない上書き防止:
      タスク自動リセット処理が、ユーザーが設定した将来のdueDateを持つTaskインスタンスのdueDateを、意図せず
  過去の日付に書き換えてしまう可能性がありました。この修正により、TaskのdueDateが将来の日付である場合は保
  護され、タスクの期限設定の整合性が保たれます。