### PR TITLE
Task permission

### DIFF
--- a/src/main/java/com/habit/client/ChatController.java
+++ b/src/main/java/com/habit/client/ChatController.java
@@ -38,7 +38,8 @@ public class ChatController {
   private String userId;
   private String teamID;
   private String teamName = "チーム名未取得";
-  private String creatorId; // チーム作成者のID
+  private String creatorId;
+  private com.habit.domain.Team team;
 
   // creatorIdのセッター
   public void setCreatorId(String creatorId) {
@@ -53,12 +54,14 @@ public class ChatController {
     fetchAndSetTeamName(teamID);
     loadChatLog(); // teamIDがセットされた後に履歴を取得
   }
-
   public void setTeamName(String teamName) {
     this.teamName = teamName;
     if (teamNameLabel != null) {
       teamNameLabel.setText(teamName);
     }
+  }
+  public void setTeam(com.habit.domain.Team team) {
+    this.team = team;
   }
 
   /**
@@ -176,6 +179,7 @@ public class ChatController {
         controller.setTeamID(teamID);
         controller.setTeamName(teamName);
         controller.setCreatorId(creatorId);
+        controller.setTeam(team);
         javafx.stage.Stage stage =
             (javafx.stage.Stage)btnBackToTeamTop.getScene().getWindow();
         stage.setScene(new javafx.scene.Scene(root));

--- a/src/main/java/com/habit/client/ChatController.java
+++ b/src/main/java/com/habit/client/ChatController.java
@@ -12,8 +12,12 @@ import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.scene.control.*;
 import org.json.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ChatController {
+  private static final Logger logger =
+      LoggerFactory.getLogger(ChatController.class);
   /* チーム名ラベル */
   @FXML private Label teamNameLabel;
   /* チャットリスト */
@@ -34,6 +38,13 @@ public class ChatController {
   private String userId;
   private String teamID;
   private String teamName = "チーム名未取得";
+  private String creatorId; // チーム作成者のID
+
+  // creatorIdのセッター
+  public void setCreatorId(String creatorId) {
+    logger.info("creatorId set: " + creatorId);
+    this.creatorId = creatorId;
+  }
 
   public void setUserId(String userId) { this.userId = userId; }
 
@@ -164,6 +175,7 @@ public class ChatController {
         controller.setUserId(userId);
         controller.setTeamID(teamID);
         controller.setTeamName(teamName);
+        controller.setCreatorId(creatorId);
         javafx.stage.Stage stage =
             (javafx.stage.Stage)btnBackToTeamTop.getScene().getWindow();
         stage.setScene(new javafx.scene.Scene(root));

--- a/src/main/java/com/habit/client/CreateTeamController.java
+++ b/src/main/java/com/habit/client/CreateTeamController.java
@@ -67,7 +67,7 @@ public class CreateTeamController {
         // 初期値設定
         maxMembersSpinner.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(1, 30, 5));
         editPermissionChoice.setItems(FXCollections.observableArrayList("自分だけ", "自由"));
-        editPermissionChoice.getSelectionModel().selectFirst();
+        editPermissionChoice.setValue("自由");
         inviteList.setItems(invitedMembers);
 
         // メンバー追加ボタンのアクション設定
@@ -153,15 +153,10 @@ public class CreateTeamController {
                     }
                     
                     javafx.stage.Stage stage = (javafx.stage.Stage) btnCreateTeam.getScene().getWindow();
-                    javafx.fxml.FXMLLoader loader = new javafx.fxml.FXMLLoader(getClass().getResource("/com/habit/client/gui/TeamTop.fxml"));
+                    javafx.fxml.FXMLLoader loader = new javafx.fxml.FXMLLoader(getClass().getResource("/com/habit/client/gui/Home.fxml"));
                     javafx.scene.Parent root = loader.load();
-                    TeamTopController controller = loader.getController();
-                    controller.setUserId(userId);
-                    controller.setTeamName(teamName);
-                    controller.setTeamID(createdTeamId); // チームIDは最後にセット
-                    controller.setCreatorId(userId); // チーム作成者のIDをセット
                     stage.setScene(new javafx.scene.Scene(root));
-                    stage.setTitle("チームトップ");
+                    stage.setTitle("ホーム");
 
                     // チーム作成後すぐタスク作成画面に遷移する場合はこちら
                     /*

--- a/src/main/java/com/habit/client/CreateTeamController.java
+++ b/src/main/java/com/habit/client/CreateTeamController.java
@@ -159,6 +159,7 @@ public class CreateTeamController {
                     controller.setUserId(userId);
                     controller.setTeamName(teamName);
                     controller.setTeamID(createdTeamId); // チームIDは最後にセット
+                    controller.setCreatorId(userId); // チーム作成者のIDをセット
                     stage.setScene(new javafx.scene.Scene(root));
                     stage.setTitle("チームトップ");
 

--- a/src/main/java/com/habit/client/HomeController.java
+++ b/src/main/java/com/habit/client/HomeController.java
@@ -339,6 +339,7 @@ public class HomeController {
             com.habit.client.TeamTopController controller = loader.getController();
             controller.setTeamName(selectedTeam.getteamName());
             controller.setTeamID(selectedTeam.getTeamID());
+            controller.setCreatorId(selectedTeam.getCreatorId()); // creatorIdを渡す
             if (userId != null) {
               controller.setUserId(userId);
             }

--- a/src/main/java/com/habit/client/HomeController.java
+++ b/src/main/java/com/habit/client/HomeController.java
@@ -91,7 +91,7 @@ public class HomeController {
               teamJson.getString("teamId"),
               teamJson.getString("teamName"),
               teamJson.getString("creatorId"),
-              com.habit.domain.TeamMode.FIXED_TASK_MODE // Default value
+              teamJson.optString("editPermission", "自分だけ") // "自分だけ"をデフォルト値とする
           );
           teams.add(team);
         }
@@ -337,6 +337,7 @@ public class HomeController {
                 getClass().getResource("/com/habit/client/gui/TeamTop.fxml"));
             javafx.scene.Parent root = loader.load();
             com.habit.client.TeamTopController controller = loader.getController();
+            controller.setTeam(selectedTeam); // ★ Teamオブジェクトを渡す
             controller.setTeamName(selectedTeam.getteamName());
             controller.setTeamID(selectedTeam.getTeamID());
             controller.setCreatorId(selectedTeam.getCreatorId()); // creatorIdを渡す

--- a/src/main/java/com/habit/client/PersonalPageController.java
+++ b/src/main/java/com/habit/client/PersonalPageController.java
@@ -10,8 +10,7 @@ import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import java.time.*;
 import java.util.*;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +45,7 @@ public class PersonalPageController {
     private String userId;
     private String teamID;
     private String teamName = "チーム名未取得";
+    private String creatorId;
 
     public void setUserId(String userId) {
         this.userId = userId;
@@ -55,6 +55,10 @@ public class PersonalPageController {
     }
     public void setTeamName(String teamName) {
         this.teamName = teamName;
+    }
+    public void setCreatorId(String creatorId) {
+        logger.info("creatorId set: " + creatorId);
+        this.creatorId = creatorId;
     }
 
     /**
@@ -73,6 +77,7 @@ public class PersonalPageController {
                 controller.setUserId(userId);
                 controller.setTeamID(teamID);
                 controller.setTeamName(teamName);
+                controller.setCreatorId(creatorId);
                 Stage stage = (Stage) btnBackToTeam.getScene().getWindow();
                 stage.setScene(new Scene(root));
                 stage.setTitle("チームトップページ");

--- a/src/main/java/com/habit/client/PersonalPageController.java
+++ b/src/main/java/com/habit/client/PersonalPageController.java
@@ -46,6 +46,7 @@ public class PersonalPageController {
     private String teamID;
     private String teamName = "チーム名未取得";
     private String creatorId;
+    private com.habit.domain.Team team;
 
     public void setUserId(String userId) {
         this.userId = userId;
@@ -59,6 +60,9 @@ public class PersonalPageController {
     public void setCreatorId(String creatorId) {
         logger.info("creatorId set: " + creatorId);
         this.creatorId = creatorId;
+    }
+    public void setTeam(com.habit.domain.Team team) {
+        this.team = team;
     }
 
     /**
@@ -78,6 +82,7 @@ public class PersonalPageController {
                 controller.setTeamID(teamID);
                 controller.setTeamName(teamName);
                 controller.setCreatorId(creatorId);
+                controller.setTeam(team);
                 Stage stage = (Stage) btnBackToTeam.getScene().getWindow();
                 stage.setScene(new Scene(root));
                 stage.setTitle("チームトップページ");

--- a/src/main/java/com/habit/client/SearchTeamController.java
+++ b/src/main/java/com/habit/client/SearchTeamController.java
@@ -132,14 +132,16 @@ public class SearchTeamController {
                     
                     // チームトップ画面へ遷移
                     Stage stage = (Stage) btnJoin.getScene().getWindow();
-                    FXMLLoader loader = new FXMLLoader(getClass().getResource("/com/habit/client/gui/TeamTop.fxml"));
+                    // ホーム画面に遷移
+                    FXMLLoader loader = new FXMLLoader(getClass().getResource("/com/habit/client/gui/Home.fxml"));
                     Parent root = loader.load();
-                    TeamTopController controller = loader.getController();
-                    controller.setTeamName(foundTeamName);
-                    controller.setUserId(userId);
-                    controller.setTeamID(actualTeamId); // 正しいチームIDを設定
+
+                    // HomeControllerにデータを渡す必要があればここで渡します
+                    // HomeController homeController = loader.getController();
+                    // homeController.setUserId(userId);
+                    
                     stage.setScene(new Scene(root));
-                    stage.setTitle("チームトップ");
+                    stage.setTitle("ホーム");
                 } else {
                     resultLabel.setText("参加失敗: " + body);
                 }

--- a/src/main/java/com/habit/client/TaskCreateController.java
+++ b/src/main/java/com/habit/client/TaskCreateController.java
@@ -40,17 +40,20 @@ public class TaskCreateController {
     private String userId;
     private String teamID;
     private String teamName = "チーム名未取得";
+    private String creatorId;
 
     public void setUserId(String userId) {
         this.userId = userId;
     }
-
     public void setTeamID(String teamID) {
         this.teamID = teamID;
     }
-
     public void setTeamName(String teamName) {
         this.teamName = teamName;
+    }
+    public void setCreatorId(String creatorId) {
+        logger.info("creatorId set: " + creatorId);
+        this.creatorId = creatorId;
     }
 
     /**
@@ -160,6 +163,7 @@ public class TaskCreateController {
             controller.setUserId(userId);
             controller.setTeamID(teamID);
             controller.setTeamName(teamName);
+            controller.setCreatorId(creatorId);
             stage.setScene(new javafx.scene.Scene(root));
             stage.setTitle("チームトップ");
             stage.show();
@@ -180,6 +184,7 @@ public class TaskCreateController {
             controller.setUserId(userId);
             controller.setTeamID(teamID);
             controller.setTeamName(teamName);
+            controller.setCreatorId(creatorId);
             stage.setScene(new javafx.scene.Scene(root));
             stage.setTitle("チームトップ");
             stage.show();

--- a/src/main/java/com/habit/client/TaskCreateController.java
+++ b/src/main/java/com/habit/client/TaskCreateController.java
@@ -41,6 +41,7 @@ public class TaskCreateController {
     private String teamID;
     private String teamName = "チーム名未取得";
     private String creatorId;
+    private com.habit.domain.Team team;
 
     public void setUserId(String userId) {
         this.userId = userId;
@@ -54,6 +55,9 @@ public class TaskCreateController {
     public void setCreatorId(String creatorId) {
         logger.info("creatorId set: " + creatorId);
         this.creatorId = creatorId;
+    }
+    public void setTeam(com.habit.domain.Team team) {
+        this.team = team;
     }
 
     /**
@@ -164,6 +168,7 @@ public class TaskCreateController {
             controller.setTeamID(teamID);
             controller.setTeamName(teamName);
             controller.setCreatorId(creatorId);
+            controller.setTeam(team);
             stage.setScene(new javafx.scene.Scene(root));
             stage.setTitle("チームトップ");
             stage.show();
@@ -185,6 +190,7 @@ public class TaskCreateController {
             controller.setTeamID(teamID);
             controller.setTeamName(teamName);
             controller.setCreatorId(creatorId);
+            controller.setTeam(team);
             stage.setScene(new javafx.scene.Scene(root));
             stage.setTitle("チームトップ");
             stage.show();

--- a/src/main/java/com/habit/client/TeamTopController.java
+++ b/src/main/java/com/habit/client/TeamTopController.java
@@ -65,6 +65,12 @@ public class TeamTopController {
   private String teamID;
   private String teamName = "チーム名未取得";
   private String creatorId; // チーム作成者のID
+  private com.habit.domain.Team team; // チーム情報を保持するフィールド
+
+  // teamのセッター
+  public void setTeam(com.habit.domain.Team team) {
+    this.team = team;
+  }
 
   // creatorIdのセッター
   public void setCreatorId(String creatorId) {
@@ -306,6 +312,7 @@ public class TeamTopController {
         controller.setTeamID(teamID);
         controller.setTeamName(teamName);
         controller.setCreatorId(creatorId);
+        controller.setTeam(team);
         // ★修正：空のリストを渡してAPIから最新データを取得させる
         controller.setUserTasks(new java.util.ArrayList<>());
         javafx.stage.Stage stage =
@@ -330,6 +337,7 @@ public class TeamTopController {
         controller.setTeamID(teamID);
         controller.setTeamName(teamName);
         controller.setCreatorId(creatorId);
+        controller.setTeam(team);
         javafx.stage.Stage stage =
             (javafx.stage.Stage)btnToChat.getScene().getWindow();
         stage.setScene(new javafx.scene.Scene(root));
@@ -341,35 +349,57 @@ public class TeamTopController {
 
     // タスク作成ボタンのアクション設定
     btnCreateTask.setOnAction(unused -> {
-      // チーム作成者のみがタスクを作成できるように制限
-      if (userId == null || creatorId == null || !userId.equals(creatorId)) {
+      if (team == null) {
+        // teamオブジェクトがnullの場合はエラーメッセージを表示して処理を中断
+        Platform.runLater(() -> {
+          Alert alert = new Alert(Alert.AlertType.ERROR);
+          alert.setTitle("エラー");
+          alert.setHeaderText(null);
+          alert.setContentText("チーム情報が取得できませんでした。");
+          alert.showAndWait();
+        });
+        return;
+      }
+
+      boolean canCreateTask = false;
+      String editPermission = team.getEditPermission();
+
+      if ("自由".equals(editPermission)) {
+        canCreateTask = true;
+      } else if ("自分だけ".equals(editPermission)) {
+        if (userId != null && creatorId != null && userId.equals(creatorId)) {
+          canCreateTask = true;
+        }
+      }
+
+      if (canCreateTask) {
+        try {
+          javafx.fxml.FXMLLoader loader = new javafx.fxml.FXMLLoader(
+              getClass().getResource("/com/habit/client/gui/TaskCreate.fxml"));
+          javafx.scene.Parent root = loader.load();
+          // TaskCreateControllerを取得
+          TaskCreateController controller = loader.getController();
+          // 各データを渡す
+          controller.setUserId(userId);
+          controller.setTeamID(teamID);
+          controller.setTeamName(teamName);
+          controller.setCreatorId(creatorId);
+          controller.setTeam(team);
+          javafx.stage.Stage stage =
+              (javafx.stage.Stage)btnCreateTask.getScene().getWindow();
+          stage.setScene(new javafx.scene.Scene(root));
+          stage.setTitle("タスク作成");
+        } catch (Exception ex) {
+          ex.printStackTrace();
+        }
+      } else {
         Platform.runLater(() -> {
           Alert alert = new Alert(Alert.AlertType.WARNING);
           alert.setTitle("権限エラー");
           alert.setHeaderText(null);
-          alert.setContentText("このチームではタスクを作成できるのはチームの作成者のみです。");
+          alert.setContentText("このチームではタスクを作成する権限がありません。");
           alert.showAndWait();
         });
-        return; // タスク作成画面への遷移をブロック
-      }
-
-      try {
-        javafx.fxml.FXMLLoader loader = new javafx.fxml.FXMLLoader(
-            getClass().getResource("/com/habit/client/gui/TaskCreate.fxml"));
-        javafx.scene.Parent root = loader.load();
-        // TaskCreateControllerを取得
-        TaskCreateController controller = loader.getController();
-        // 各データを渡す
-        controller.setUserId(userId);
-        controller.setTeamID(teamID);
-        controller.setTeamName(teamName);
-        controller.setCreatorId(creatorId);
-        javafx.stage.Stage stage =
-            (javafx.stage.Stage)btnCreateTask.getScene().getWindow();
-        stage.setScene(new javafx.scene.Scene(root));
-        stage.setTitle("タスク作成");
-      } catch (Exception ex) {
-        ex.printStackTrace();
       }
     });
 

--- a/src/main/java/com/habit/client/TeamTopController.java
+++ b/src/main/java/com/habit/client/TeamTopController.java
@@ -64,6 +64,13 @@ public class TeamTopController {
   private String userId;
   private String teamID;
   private String teamName = "チーム名未取得";
+  private String creatorId; // チーム作成者のID
+
+  // creatorIdのセッター
+  public void setCreatorId(String creatorId) {
+    logger.info("creatorId set: " + creatorId);
+    this.creatorId = creatorId;
+  }
   // ユーザIDのセッター
   public void setUserId(String userId) {
     logger.info("userId set: " + userId);
@@ -298,6 +305,7 @@ public class TeamTopController {
         controller.setUserId(userId);
         controller.setTeamID(teamID);
         controller.setTeamName(teamName);
+        controller.setCreatorId(creatorId);
         // ★修正：空のリストを渡してAPIから最新データを取得させる
         controller.setUserTasks(new java.util.ArrayList<>());
         javafx.stage.Stage stage =
@@ -321,6 +329,7 @@ public class TeamTopController {
         controller.setUserId(userId);
         controller.setTeamID(teamID);
         controller.setTeamName(teamName);
+        controller.setCreatorId(creatorId);
         javafx.stage.Stage stage =
             (javafx.stage.Stage)btnToChat.getScene().getWindow();
         stage.setScene(new javafx.scene.Scene(root));
@@ -332,6 +341,18 @@ public class TeamTopController {
 
     // タスク作成ボタンのアクション設定
     btnCreateTask.setOnAction(unused -> {
+      // チーム作成者のみがタスクを作成できるように制限
+      if (userId == null || creatorId == null || !userId.equals(creatorId)) {
+        Platform.runLater(() -> {
+          Alert alert = new Alert(Alert.AlertType.WARNING);
+          alert.setTitle("権限エラー");
+          alert.setHeaderText(null);
+          alert.setContentText("このチームではタスクを作成できるのはチームの作成者のみです。");
+          alert.showAndWait();
+        });
+        return; // タスク作成画面への遷移をブロック
+      }
+
       try {
         javafx.fxml.FXMLLoader loader = new javafx.fxml.FXMLLoader(
             getClass().getResource("/com/habit/client/gui/TaskCreate.fxml"));
@@ -342,6 +363,7 @@ public class TeamTopController {
         controller.setUserId(userId);
         controller.setTeamID(teamID);
         controller.setTeamName(teamName);
+        controller.setCreatorId(creatorId);
         javafx.stage.Stage stage =
             (javafx.stage.Stage)btnCreateTask.getScene().getWindow();
         stage.setScene(new javafx.scene.Scene(root));
@@ -570,6 +592,7 @@ public class TeamTopController {
                                         controller.setUserId(userId);
                                         controller.setTeamID(teamID);
                                         controller.setTeamName(teamName);
+                                        controller.setCreatorId(creatorId);
                                         // ユーザーのタスク一覧を渡す
                                         controller.setUserTasks(getUserTasksForPersonalPage());
                                         javafx.stage.Stage stage = (javafx.stage.Stage) btnToPersonal.getScene().getWindow();

--- a/src/main/java/com/habit/domain/Team.java
+++ b/src/main/java/com/habit/domain/Team.java
@@ -10,15 +10,15 @@ public class Team {
     private String teamID;
     private String teamName;
     private String creatorId;
-    private TeamMode mode;
+    private String editPermission; // modeから変更
     private List<String> memberIds;
     private List<Task> teamTasks;
 
-    public Team(String teamID, String teamName, String creatorId, TeamMode mode) {
+    public Team(String teamID, String teamName, String creatorId, String editPermission) {
         this.teamID = teamID;
         this.teamName = teamName;
         this.creatorId = creatorId;
-        this.mode = mode;
+        this.editPermission = editPermission; // modeから変更
         this.memberIds = new ArrayList<>();
         this.teamTasks = new ArrayList<>();
     }
@@ -38,13 +38,12 @@ public class Team {
     }
 
     public void addTeamTask(Task task) {
-        if (mode == TeamMode.FIXED_TASK_MODE) {
-            teamTasks.add(task);
-        }
+        // タスク追加ロジックは一旦シンプルにします（必要に応じて復活させます）
+        teamTasks.add(task);
     }
 
-    public TeamMode getMode() {
-        return mode;
+    public String getEditPermission() { // getModeから変更
+        return editPermission;
     }
 
     public String getTeamID() {

--- a/src/main/java/com/habit/domain/TeamMode.java
+++ b/src/main/java/com/habit/domain/TeamMode.java
@@ -1,9 +1,0 @@
-package com.habit.domain;
-
-/**
- * チームのモード種別を表す列挙型。
- */
-public enum TeamMode {
-    FREE_TASK_MODE,
-    FIXED_TASK_MODE
-}

--- a/src/main/java/com/habit/server/controller/TeamController.java
+++ b/src/main/java/com/habit/server/controller/TeamController.java
@@ -1,7 +1,6 @@
 package com.habit.server.controller;
 
 import com.habit.domain.Team;
-import com.habit.domain.TeamMode;
 import com.habit.server.repository.TaskRepository;
 import com.habit.server.repository.TeamRepository;
 import com.habit.server.repository.UserRepository;
@@ -157,8 +156,7 @@ public class TeamController {
         }
         if (creatorUserId == null)
           creatorUserId = "creator"; // フォールバック
-        Team team =
-            new Team(teamID, teamName, creatorUserId, TeamMode.FIXED_TASK_MODE);
+        Team team = new Team(teamID, teamName, creatorUserId, editPerm);
         team.setteamName(teamName);
         TeamRepository repo = new TeamRepository();
         repo.save(team, passcode, maxMembers, editPerm,

--- a/src/main/java/com/habit/server/controller/UserController.java
+++ b/src/main/java/com/habit/server/controller/UserController.java
@@ -82,6 +82,7 @@ public class UserController {
               teamJson.put("teamId", team.getTeamID());
               teamJson.put("teamName", team.getteamName());
               teamJson.put("creatorId", team.getCreatorId());
+              teamJson.put("editPermission", team.getEditPermission()); // ★ 不足していた行を追加
               responseArray.put(teamJson);
             }
           }

--- a/src/main/java/com/habit/server/repository/TeamRepository.java
+++ b/src/main/java/com/habit/server/repository/TeamRepository.java
@@ -313,14 +313,11 @@ public class TeamRepository {
         pstmt.setString(1, teamId);
         ResultSet rs = pstmt.executeQuery();
         if (rs.next()) {
-          // TeamModeは簡略化（実際の実装に合わせて調整）
-          com.habit.domain.TeamMode mode = com.habit.domain.TeamMode.FIXED_TASK_MODE; // デフォルト値
-          
           Team team = new Team(
             rs.getString("id"),
             rs.getString("teamName"),
             rs.getString("creatorId"),
-            mode
+            rs.getString("editPermission")
           );
           
           // メンバー一覧を取得して設定


### PR DESCRIPTION
## feat. タスクの編集権限機能実装

### 概要
  チームのタスク作成権限に関するロジックを全面的に実装しました。主な変更点として、チーム作成時に選択したタスクの編集権限が正しくアプリケーション全体で反映されるようにしました。
  また、ユーザー体験を向上させるため、チーム作成・参加後の画面遷移を、直接チームトップページに飛ぶのではなく、一度ホーム画面に戻るように統一しました。

### 主な変更点
   1. タスク編集権限機能の導入とリファクタリング
       * `TeamMode`の廃止と`editPermission`への統一:
           * 従来、使用されていなかったTeamModeというEnumを廃止しました。
           * 代わりに、権限設定を明確に表すString型のeditPermissionフィールドをTeamドメインクラスに導入しました。これにより、権限の状態が「自分だけ」「自由」といった文字列で管理されるようになります
             。
       * サーバーサイドの対応:
           * TeamController: チーム作成API (/createTeam) が、クライアントから送信されるeditPermissionの値を受け取り、データベースに正しく保存するように修正しました。
           * UserController: 参加済みチームの情報を返すAPI (/getJoinedTeamInfo) が、レスポンスJSONにeditPermissionの値を必ず含めるように修正しました。
           * TeamRepository: データベースとのやり取りにおいて、editPermissionカラムの読み書きを正しく行うように修正しました。

   2. クライアントサイドの権限チェック対応
       * `TeamTopController`の権限チェックロジック修正:
           * タスク作成ボタン (btnCreateTask) がクリックされた際に、team.getEditPermission()から取得した値に基づき、タスク作成画面への遷移を制御するようにロジックを全面的に改修しました。
       * `CreateTeamController`のUI改善:
           * チーム作成画面の権限選択ChoiceBoxのデフォルト値を、より利用頻度が高いと想定される「自由」に設定しました。
       * `HomeController`のデータ連携修正:
           * サーバーから取得したチーム情報 (editPermissionを含む) からTeamオブジェクトを正しく生成し、チームトップ画面へ遷移する際にTeamTopControllerへ完全なTeamオブジェクトを渡すように修正しました。他の画面遷移においてもTeamオブジェクトを渡すようにしています。(これにより、TeamID, TeamNameの受け渡しは廃止する方針です)

   3. 画面遷移の統一 (UX改善)
       * `CreateTeamController`: チーム作成後、チームトップ画面に直接遷移するのではなく、ホーム画面に戻るように変更しました。
       * `SearchTeamController`: チーム参加後も同様に、ホーム画面に戻るように画面遷移を統一しました。
       * これにより、ユーザーは作成・参加したチームがチーム一覧に追加されたことを自然に確認でき、一貫した操作感を提供します。
       * 一度ホームに戻ることで、Teamオブジェクトの受け渡し処理を簡単にしています。

   4. その他
       * 画面遷移時にTeamオブジェクトや関連情報 (creatorIdなど) が他のコントローラーへ適切に引き継がれるよう、複数のコントローラー (ChatController, PersonalPageController, TaskCreateControllerなど)
         のデータ連携部分を修正しました。

### テスト方法
 1. チーム作成時、及びチーム参加時にホーム画面に遷移し、チームリストに新しいチームが追加されることを確認してください。
 2. 公開範囲 "自由" のチームを作成し、作成者および他のメンバーが、どの画面を経由した後でもタスク作成ができることを確認してください。
 3. 公開範囲 "自分のみ" のチームを作成し、作成者がどの画面を経由した後でもタスク作成ができることを確認してください。また、作成者以外のメンバーはどの画面を経由した後でも、タスク作成ボタンを押すと、作成できないことを示すポップアップが現れることを確認してください。
    
### 今後の展望
 今回実装した権限管理を元に、権限に応じてタスクを削除する機能を実装したいと考えています。