### PR TITLE
Fix double point

### DIFF
--- a/src/main/java/com/habit/server/scheduler/TaskAutoResetScheduler.java
+++ b/src/main/java/com/habit/server/scheduler/TaskAutoResetScheduler.java
@@ -94,6 +94,14 @@ public class TaskAutoResetScheduler {
         logger.info("スレッド: " + Thread.currentThread().getName());
         
         try {
+            // 1秒の遅延を挿入
+            try {
+                Thread.sleep(1000); // 1000ミリ秒 = 1秒
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt(); // 割り込みを再設定
+                logger.warn("タスク自動再設定の遅延中に割り込みが発生しました。", ie);
+            }
+
             // メイン処理を実行
             taskAutoResetService.runScheduledCheck();
             

--- a/src/main/java/com/habit/server/service/TaskAutoResetService.java
+++ b/src/main/java/com/habit/server/service/TaskAutoResetService.java
@@ -214,10 +214,9 @@ public class TaskAutoResetService {
                         int changeAmount;
 
                         if(oldStatus.isDone()) {
-                            // 完了していたらポイントを減らす（0未満にはしない）
-                            newPoints = Math.max(0, currentPoints - 1);
-                            changeAmount = newPoints - currentPoints;
-                            logger.info("[INFO] タスク完了により " + user.getUsername() + " のサボりポイントを減少");
+                            // ポイント処理は何もしない
+                            newPoints = currentPoints;
+                            changeAmount = 0;
                         } else {
                             // 未完了ならポイントを増やす（9を超えない）
                             newPoints = Math.min(9, currentPoints + 1);

--- a/src/test/java/com/habit/server/service/TaskAutoResetServiceTest.java
+++ b/src/test/java/com/habit/server/service/TaskAutoResetServiceTest.java
@@ -237,9 +237,6 @@ class TaskAutoResetServiceTest {
         taskAutoResetService.checkAndResetTasks(teamId, today);
 
         // --- Then (検証) ---
-        // サボりポイントが1減少していることを確認
-        com.habit.domain.User updatedUser = userRepository.findById(userId);
-        assertNotNull(updatedUser);
-        assertEquals(4, updatedUser.getSabotagePoints(), "完了タスクでサボりポイントが1減少するはず");
+        // checkAndResetTasksは完了済みタスクのサボりポイントを変動させないため、ここでは検証しない
     }
 }


### PR DESCRIPTION
- 完了したタスクについて、タスク完了時と再設定時で二重にポイント計算していた問題を修正しました。完了した時のみポイント減算が行われます。
- 再設定処理開始前に1sの遅延を入れることで、誤差により前日23:59:59に再設定処理が開始してしまう可能性を排除しました。