### PR TITLE
チャット関連のUI改良

### DIFF
--- a/src/main/java/com/habit/client/ChatController.java
+++ b/src/main/java/com/habit/client/ChatController.java
@@ -138,15 +138,15 @@ public class ChatController {
           setText(null);
           setContextMenu(null);
         } else {
-          // メッセージのテキストを設定
+          // メッセージのテキストを username:contents[timestamp] 形式で設定
           final String formatPattern = "yyyy-MM-dd HH:mm:ss";
           StringBuilder sb = new StringBuilder();
-          sb.append("[" +
-              message.getTimestamp().format(
-                  DateTimeFormatter.ofPattern(formatPattern)) +
-              "]");
-          sb.append("[" + message.getSender().getUsername() + "]");
-          sb.append(": " + message.getContent());
+          sb.append(message.getSender().getUsername());
+          sb.append(": ");
+          sb.append(message.getContent());
+          sb.append("[");
+          sb.append(message.getTimestamp().format(DateTimeFormatter.ofPattern(formatPattern)));
+          sb.append("]");
           setText(sb.toString());
 
           // 自分のメッセージの場合のみContextMenuを設定

--- a/src/main/resources/com/habit/client/gui/Chat.fxml
+++ b/src/main/resources/com/habit/client/gui/Chat.fxml
@@ -7,13 +7,13 @@
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.AnchorPane?>
 
-<AnchorPane stylesheets="@Chat.css" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.habit.client.ChatController">
-    <Label fx:id="teamNameLabel" layoutX="20" layoutY="0" prefHeight="20" prefWidth="360" text="チーム名" AnchorPane.leftAnchor="20.0" />
-    <ListView fx:id="chatList" focusTraversable="false" layoutX="20" layoutY="20" prefHeight="300" prefWidth="360" styleClass="listView" AnchorPane.leftAnchor="20.0" AnchorPane.rightAnchor="20.0" />
-    <TextField fx:id="chatInput" layoutX="20" layoutY="330" prefWidth="280" AnchorPane.leftAnchor="20.0" />
-    <Button fx:id="btnSend" layoutX="310" layoutY="330" prefWidth="70" text="送信" AnchorPane.leftAnchor="310.0" />
-    <Button fx:id="btnBackToTeamTop" layoutX="20" layoutY="370" prefWidth="120" text="チームトップへ戻る" AnchorPane.leftAnchor="20.0" />
+<AnchorPane stylesheets="@Chat.css" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.habit.client.ChatController" prefWidth="900.0" prefHeight="700.0">
+    <Label fx:id="teamNameLabel" layoutX="40" layoutY="0" prefHeight="40" prefWidth="800" text="チーム名" AnchorPane.leftAnchor="40.0" />
+    <ListView fx:id="chatList" focusTraversable="false" layoutX="40" layoutY="60" prefHeight="500" prefWidth="800" styleClass="listView" AnchorPane.leftAnchor="40.0" AnchorPane.rightAnchor="40.0" />
+    <TextField fx:id="chatInput" layoutX="40" layoutY="580" prefWidth="650" prefHeight="40" AnchorPane.leftAnchor="40.0" />
+    <Button fx:id="btnSend" layoutX="710" layoutY="580" prefWidth="130" prefHeight="40" text="送信" AnchorPane.leftAnchor="710.0" />
+    <Button fx:id="btnBackToTeamTop" layoutX="40" layoutY="640" prefWidth="200" prefHeight="40" text="チームトップへ戻る" AnchorPane.leftAnchor="40.0" />
    <padding>
-      <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+      <Insets bottom="20.0" left="20.0" right="20.0" top="20.0" />
    </padding>
 </AnchorPane>

--- a/src/main/resources/com/habit/client/gui/TeamTop.fxml
+++ b/src/main/resources/com/habit/client/gui/TeamTop.fxml
@@ -5,7 +5,7 @@
 <?import javafx.scene.image.ImageView?>
 
 <BorderPane xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
-      fx:controller="com.habit.client.TeamTopController" prefWidth="900" prefHeight="550" stylesheets="@TeamTop.css">
+      fx:controller="com.habit.client.TeamTopController" prefWidth="1200" prefHeight="550" stylesheets="@TeamTop.css">
     <top>
         <HBox spacing="20" alignment="CENTER">
             <Button fx:id="btnBackHome" text="ホームに戻る" styleClass="custom-button"/>
@@ -32,7 +32,7 @@
             </VBox>
             
             <!-- 右側: タスク表とその他の要素 -->
-            <VBox spacing="10" prefWidth="580">
+            <VBox spacing="10" prefWidth="880">
                 <TableView fx:id="taskTable" styleClass="taskTable" prefHeight="350"/>
                 <HBox spacing="20">
                     <VBox>
@@ -41,7 +41,7 @@
                         <Button text="(！)" fx:id="btnToPersonal" styleClass="btnToChat" prefHeight="10"/>
                         <Label text="本日の未消化タスク一覧" style="-fx-font-size: 12; -fx-padding: 3 0 0 0;"/>
                         </HBox>
-                        <ListView fx:id="todayTaskList" prefHeight="120" prefWidth="280" styleClass="todayTaskList"/>
+                        <ListView fx:id="todayTaskList" prefHeight="120" prefWidth="400" styleClass="todayTaskList"/>
                     </VBox>
                     <VBox>
                         <HBox>
@@ -49,7 +49,7 @@
                         <Button text="💭" fx:id="btnToChat" styleClass="btnToChat" prefHeight="10"/>
                         <Button fx:id="btnToChatMain" text="💬 チャット" style="-fx-background-color:rgb(89, 163, 253); -fx-text-fill: white; -fx-font-weight: bold; -fx-font-size: 16px; -fx-padding: 3 7;"/>
                         </HBox>
-                        <ListView fx:id="chatList" prefHeight="120" prefWidth="280" styleClass="chatList"/>
+                        <ListView fx:id="chatList" prefHeight="120" prefWidth="500" styleClass="chatList"/>
                     </VBox>
                 </HBox>
             </VBox>


### PR DESCRIPTION
## チームトップの横幅めちゃ広くしてしまった！実験的に
**チャット枠の横幅広いほうが見やすいかなって。不評だったら戻します**
メッセージのフォーマット調整、チャットログの処理最適化、およびユーザーインターフェース要素のサイズ変更による使いやすさの向上が含まれます。

### チャット機能の強化:
* **メッセージフォーマットの更新**: `ChatController`内の`updateItem`メソッドを修正し、メッセージを`username:contents[timestamp]`形式でフォーマットして読みやすさを向上させました。（`[src/main/java/com/habit/client/ChatController.javaL141-R149]
* **チャットログの最適化**: `TeamTopController`内の`loadChatLog`メソッドを更新し、最大50件のメッセージを取得し、タイムスタンプで降順に並べ替え、最新の3件のメッセージを抽出し、表示用にその順序を逆転させるようにしました。
### ユーザーインターフェースの改善:
* **チャット画面のサイズ調整**: `Chat.fxml`内のUI要素の寸法を調整し、チャットリストと入力フィールドを拡大して使いやすさを向上させました。（`[src/main/resources/com/habit/client/gui/Chat.fxmlL10-R17](
* **チームトップ画面のレイアウト調整**: `TeamTop.fxml`内のタスクリストやチャットリストなど、さまざまなUIコンポーネントの幅を拡大し、より多くのコンテンツを表示可能にし、レイアウトの一貫性を向上させました。（`[[1]]