### PR TITLE
ユーザ・チームの重複チェック

### DIFF
--- a/src/main/java/com/habit/client/CreateTeamController.java
+++ b/src/main/java/com/habit/client/CreateTeamController.java
@@ -168,7 +168,11 @@ public class CreateTeamController {
                     stage.setTitle("タスク作成");
                     */
                 } else {
-                    new Alert(Alert.AlertType.ERROR, body).showAndWait();
+                    if (body.contains("そのチーム名は既に使用されています")) {
+                        new Alert(Alert.AlertType.ERROR, "そのチーム名は既に使用されています").showAndWait();
+                    } else {
+                        new Alert(Alert.AlertType.ERROR, body).showAndWait();
+                    }
                 }
             } catch (Exception ex) {
                 ex.printStackTrace();

--- a/src/main/java/com/habit/client/LoginController.java
+++ b/src/main/java/com/habit/client/LoginController.java
@@ -10,6 +10,8 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.PasswordField;
 import javafx.scene.control.TextField;
+import javafx.scene.control.Alert;
+import javafx.scene.control.Alert.AlertType;
 
 /**
  * ログイン画面のコントローラークラス。
@@ -127,11 +129,30 @@ public class LoginController {
         });
       } else {
         // サーバーからのメッセージを表示
-        loginStatusLabel.setText(responseBody);
+        if (responseBody.contains("そのユーザー名は既に使用されています")) {
+            showAlert("登録エラー", "そのユーザー名は既に使用されています。");
+        } else {
+            loginStatusLabel.setText(responseBody);
+        }
       }
     } catch (Exception ex) {
       // サーバー接続エラー時の処理
       loginStatusLabel.setText("サーバ接続エラー: " + ex.getMessage());
     }
+  }
+
+  /**
+   * エラーメッセージを表示するためのヘルパーメソッド。
+   * アラートダイアログを表示する。
+   *
+   * @param title アラートのタイトル
+   * @param content アラートの内容
+   */
+  private void showAlert(String title, String content) {
+    Alert alert = new Alert(AlertType.ERROR);
+    alert.setTitle(title);
+    alert.setHeaderText(null);
+    alert.setContentText(content);
+    alert.showAndWait();
   }
 }

--- a/src/main/java/com/habit/server/controller/AuthController.java
+++ b/src/main/java/com/habit/server/controller/AuthController.java
@@ -133,7 +133,7 @@ public class AuthController {
           }
           response = "登録成功\nSESSION_ID:" + sessionId;
         } else {
-          response = "登録失敗";
+          response = "そのユーザー名は既に使用されています";
         }
       } else {
         response = "パラメータが不正です";

--- a/src/main/java/com/habit/server/controller/TeamController.java
+++ b/src/main/java/com/habit/server/controller/TeamController.java
@@ -156,6 +156,17 @@ public class TeamController {
         }
         if (creatorUserId == null)
           creatorUserId = "creator"; // フォールバック
+
+        // チーム名の重複チェック
+        if (teamRepository.findTeamIdByName(teamName) != null) {
+          response = "{\"message\":\"そのチーム名は既に使用されています\"}";
+          exchange.sendResponseHeaders(409, response.getBytes().length);
+          OutputStream os = exchange.getResponseBody();
+          os.write(response.getBytes());
+          os.close();
+          return;
+        }
+
         Team team = new Team(teamID, teamName, creatorUserId, editPerm);
         team.setteamName(teamName);
         TeamRepository repo = new TeamRepository();

--- a/src/main/java/com/habit/server/service/AuthService.java
+++ b/src/main/java/com/habit/server/service/AuthService.java
@@ -42,6 +42,9 @@ public class AuthService {
    * 新規登録し、セッションIDを発行して返す
    */
   public String registerAndCreateSession(String username, String password) {
+    if (userRepository.findByUsername(username) != null) {
+      return null; // ユーザー名が既に存在する場合はnullを返す
+    }
     User user =
         new User(java.util.UUID.randomUUID().toString(), username, password);
     userRepository.save(user);


### PR DESCRIPTION
## feat. ユーザー名とチーム名の重複チェック機能

### 概要
  ユーザー登録時およびチーム作成時に、名前の重複をチェックする機能を追加しました。これにより、システム全体でユーザー名とチーム名が一意であることが保証され、データの整合性が向上します。
  重複が検出された場合、サーバーはエラーを返し、クライアント側ではユーザーに分かりやすいポップアップメッセージで通知します。

### 変更点
 - サーバーサイド
   1. ユーザー名の重複チェック
       - AuthService.java: registerAndCreateSessionメソッドに、指定されたユーザー名が既に存在するかどうかをデータベースで確認する処理を追加しました。
       - AuthController.java: ユーザー名が重複していた場合に、「そのユーザー名は既に使用されています」というエラーメッセージを返すように修正しました。


   2. チーム名の重複チェック
       - TeamController.java: CreateTeamHandlerに、指定されたチーム名が既に存在するかどうかを確認する処理を追加しました。
       - チーム名が重複していた場合に、「そのチーム名は既に使用されています」というエラーメッセージを返すように修正しました。

 - クライアントサイド
   1. ユーザー登録時のエラー表示
       - LoginController.java: 新規登録時にサーバーからユーザー名の重複エラーを受け取った場合、ポップアップ（Alert）を表示してユーザーに通知するように修正しました。

   2. チーム作成時のエラー表示
       - CreateTeamController.java: チーム作成時にサーバーからチーム名の重複エラーを受け取った場合、ポップアップ（Alert）を表示してユーザーに通知するように修正しました。

### テスト方法
   1. アプリケーションを起動し、新規登録画面を開きます。
   2. 既存のユーザー名 を使用して新規登録を試みます。
       - 期待される結果: 「そのユーザー名は既に使用されています」という内容のポップアップが表示されること。
   3. 未登録のユーザー名 を使用して新規登録を試みます。
       - 期待される結果: 登録が成功し、ホーム画面に遷移すること。
   4. ホーム画面からチーム作成画面を開きます。
   5. 既存のチーム名 を使用してチーム作成を試みます。
       - 期待される結果: 「そのチーム名は既に使用されています」という内容のポップアップが表示されること。
   6. 未登録のチーム名 を使用してチーム作成を試みます。
       - 期待される結果: チーム作成が成功し、ホーム画面に遷移すること。