### PR TITLE
人数上限追加

### DIFF
--- a/src/main/java/com/habit/client/CreateTeamController.java
+++ b/src/main/java/com/habit/client/CreateTeamController.java
@@ -105,6 +105,11 @@ public class CreateTeamController {
                 return;
             }
 
+            if (passcode.isEmpty()) {
+                new Alert(Alert.AlertType.ERROR, "あいことばを入力してください").showAndWait();
+                return;
+            }
+
             // サーバ連携: key=value&...形式でPOST
             try {
                 StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
チーム機能に関するいくつかの改善とバグ修正を行いました。主な変更点は以下の通りです。

   1. チーム参加時に上限人数が適用されていなかった問題を修正しました。
   2. チーム参加時のレスポンスを、既にメンバーの場合と満員の場合で明確に区別するようにしました。
   3. チーム作成時にあいことばが必須となるように修正しました。

### 変更内容

  1. チーム参加時の上限人数チェック機能の追加

  問題点:
  これまで、チーム作成時に設定した上限人数が、メンバー参加時にはチェックされておらず、上限を超えてメンバーが参加できてしまう状態でした。


  修正内容:
   - TeamRepository.javaのaddMemberByTeamNameメソッドを修正し、新しいメンバーを追加する前に、チームの現在のメンバー数とmaxMembersを比較するロジックを追加しました。
   - メンバー数が上限に達している場合は、新しいメンバーの追加を拒否するように変更しました。

  2. チーム参加時のレスポンスの明確化

  問題点:
  上記変更後、チームへの参加が失敗した場合、原因（既にメンバーである、またはチームが満員である）に関わらず、同じエラーメッセージが表示されていました。


  修正内容:
   - TeamRepository.javaのaddMemberByTeamNameメソッドの戻り値を、参加結果（成功、既にメンバー、満員）を区別できるint型に変更しました。
   - TeamController.javaのJoinTeamHandlerを修正し、addMemberByTeamNameの戻り値に応じて、クライアントに具体的なレスポンス（「参加成功」「既にメンバーです」「チームが満員です」）を返すようにしました。

  3. チーム作成時のあいことば必須化


  問題点:
  チーム作成時にあいことばが空白でも、チームが作成できてしまっていました。


  修正内容:
   - サーバーサイド (`TeamController.java`):
     - チーム作成リクエストを受け取った際に、passcodeが空でないことを検証する処理を追加しました。空の場合はエラーを返します。
   - クライアントサイド (`CreateTeamController.java`):
     - チーム作成ボタン押下時に、あいことばが入力されているかをチェックする処理を追加しました。入力されていない場合は、サーバーにリクエストを送信せずにエラーアラートを表示します。
     
### テスト方法
 - チームを作成し、その上限人数に達した状態でさらにユーザが参加しようとすると、エラーメッセージが表示されることを確かめてください。
 - 該当チームに既に参加しているユーザがもう一度参加しようとすると別のエラーメッセージが出ることを確認してください。
 - チーム作成時にあいことばを空白にするとエラーメッセージが出ることを確認してください。