### PR TITLE
サボりポイントの調整

### DIFF
--- a/src/main/java/com/habit/client/HomeController.java
+++ b/src/main/java/com/habit/client/HomeController.java
@@ -173,13 +173,13 @@ public class HomeController {
           int sabotagePoints = Integer.parseInt(body.trim());
 
           // サボりポイントに応じてレベルを計算 (0-9の範囲)
-          level = Math.max(0, 9 - sabotagePoints);
+          level = (50 - sabotagePoints) / 5;
 
           // サボりポイントが閾値を超えたら嫌がらせポップアップを表示
-          final int SABOTAGE_THRESHOLD = 5; // 5ポイント以上でポップアップ表示
+          final int SABOTAGE_THRESHOLD = 35; // 35ポイント以上でポップアップ表示
           if (sabotagePoints >= SABOTAGE_THRESHOLD) {
-            // レベルに応じてポップアップ数を増やす (5で1つ、6で2つ...)
-            int popupCount = 1 + (sabotagePoints - SABOTAGE_THRESHOLD);
+            // レベルに応じてポップアップ数を増やす (35で1つ、40で2つ...)
+            int popupCount = 1 + (sabotagePoints - SABOTAGE_THRESHOLD) / 5;
 
             Platform.runLater(() -> {
               java.util.Random random = new java.util.Random();

--- a/src/main/java/com/habit/client/TeamTopController.java
+++ b/src/main/java/com/habit/client/TeamTopController.java
@@ -144,13 +144,13 @@ public class TeamTopController {
           int sabotagePoints = Integer.parseInt(body.trim());
 
           // サボりポイントに応じてレベルを計算 (0-9の範囲)
-          level = Math.max(0, 9 - sabotagePoints);
+          level = (50 - sabotagePoints) / 5;
 
           // サボりポイントが閾値を超えたら嫌がらせポップアップを表示
-          final int SABOTAGE_THRESHOLD = 5; // 5ポイント以上でポップアップ表示
+          final int SABOTAGE_THRESHOLD = 35; // 35ポイント以上でポップアップ表示
           if (sabotagePoints >= SABOTAGE_THRESHOLD) {
-            // レベルに応じてポップアップ数を増やす (5で1つ、6で2つ...)
-            int popupCount = 1 + (sabotagePoints - SABOTAGE_THRESHOLD);
+            // レベルに応じてポップアップ数を増やす (35で1つ、40で2つ...)
+            int popupCount = 1 + (sabotagePoints - SABOTAGE_THRESHOLD) / 5;
 
             Platform.runLater(() -> {
               java.util.Random random = new java.util.Random();

--- a/src/main/java/com/habit/domain/User.java
+++ b/src/main/java/com/habit/domain/User.java
@@ -23,7 +23,7 @@ public class User {
     this.userId = userId;
     this.username = username;
     this.hashedPassword = hashedPassword;
-    this.sabotagePoints = 4; // 初期サボりポイントは4
+    this.sabotagePoints = 25; // 初期サボりポイントは25
     this.joinedTeamIds = new java.util.ArrayList<>();
   }
 
@@ -32,7 +32,14 @@ public class User {
     return Objects.equals(this.hashedPassword, password);
   }
 
-  public void addSabotagePoints(int points) { this.sabotagePoints += points; }
+  public void addSabotagePoints(int points) {
+    this.sabotagePoints += points;
+    if (this.sabotagePoints > 50) {
+        this.sabotagePoints = 50;
+    } else if (this.sabotagePoints < 0) {
+        this.sabotagePoints = 0;
+    }
+  }
 
   public int getSabotagePoints() {
         return sabotagePoints;

--- a/src/main/java/com/habit/server/controller/UserTaskStatusController.java
+++ b/src/main/java/com/habit/server/controller/UserTaskStatusController.java
@@ -400,11 +400,9 @@ public class UserTaskStatusController {
                         com.habit.server.repository.UserRepository userRepo = new com.habit.server.repository.UserRepository();
                         com.habit.domain.User user = userRepo.findById(userId[0]);
                         if (user != null) {
-                            int currentPoints = user.getSabotagePoints();
-                            int newPoints = Math.max(0, currentPoints - 1); // 0未満にはしない
-                            user.setSabotagePoints(newPoints);
+                            user.addSabotagePoints(-1);
                             userRepo.save(user);
-                            logger.info("タスク完了によりサボりポイント更新: {} {}pt → {}pt", user.getUsername(), currentPoints, newPoints);
+                            logger.info("タスク完了によりサボりポイント更新: {} {}pt", user.getUsername(), user.getSabotagePoints());
                         }
                     } catch (Exception e) {
                         logger.error("サボりポイント更新エラー: {}", e.getMessage(), e);

--- a/src/main/java/com/habit/server/repository/UserRepository.java
+++ b/src/main/java/com/habit/server/repository/UserRepository.java
@@ -98,8 +98,7 @@ public class UserRepository {
   private User mapRowToUser(ResultSet rs) throws SQLException {
     User user = new User(rs.getString("userId"), rs.getString("username"),
                          rs.getString("hashedPassword"));
-    user.addSabotagePoints(rs.getInt("sabotagePoints") -
-                           user.getSabotagePoints());
+    user.setSabotagePoints(rs.getInt("sabotagePoints"));
     // joinedTeamIdsを復元
     String joined = rs.getString("joinedTeamIds");
     if (joined != null && !joined.isEmpty()) {

--- a/src/main/java/com/habit/server/service/TaskAutoResetService.java
+++ b/src/main/java/com/habit/server/service/TaskAutoResetService.java
@@ -209,18 +209,11 @@ public class TaskAutoResetService {
                     // isDoneを判定
                     com.habit.domain.User user = userRepository.findById(oldStatus.getUserId());
                     if (user != null) {
-                        int currentPoints = user.getSabotagePoints();
-                        int newPoints;
-                        int changeAmount;
-
                         if(oldStatus.isDone()) {
                             // ポイント処理は何もしない
-                            newPoints = currentPoints;
-                            changeAmount = 0;
                         } else {
-                            // 未完了ならポイントを増やす（9を超えない）
-                            newPoints = Math.min(9, currentPoints + 1);
-                            changeAmount = newPoints - currentPoints;
+                            // 未完了ならポイントを増やす
+                            user.addSabotagePoints(5);
                             logger.info("[INFO] タスク未完了により " + user.getUsername() + " のサボりポイントを増加 → サボり報告メッセージを送信");
 
                             // サボり報告メッセージを送信
@@ -249,9 +242,8 @@ public class TaskAutoResetService {
                         }
                         
                         try {
-                            user.setSabotagePoints(newPoints);
                             userRepository.save(user);
-                            logger.info("[SUCCESS] " + user.getUsername() + " のサボりポイントを " + currentPoints + " Ptから " + newPoints + " Ptに変更 (変動量: " + (changeAmount > 0 ? "+" : "") + changeAmount + ")");
+                            logger.info("[SUCCESS] " + user.getUsername() + " のサボりポイントを更新: " + user.getSabotagePoints() + " Pt");
                         } catch (Exception userSaveException) {
                             logger.error("[ERROR] ユーザーのサボりポイント保存に失敗: " + user.getUsername() + ", エラー=" + userSaveException.getMessage());
                             userSaveException.printStackTrace();

--- a/src/test/java/com/habit/server/repository/UserRepositoryTest.java
+++ b/src/test/java/com/habit/server/repository/UserRepositoryTest.java
@@ -36,7 +36,7 @@ class UserRepositoryTest {
     assertEquals(u.getUserId(), fetched.getUserId());
     assertEquals(u.getUsername(), fetched.getUsername());
     assertEquals(u.getHashedPassword(), fetched.getHashedPassword());
-    assertEquals(9, fetched.getSabotagePoints());
+    assertEquals(30, fetched.getSabotagePoints());
     assertIterableEquals(u.getJoinedTeamIds(), fetched.getJoinedTeamIds(),
                          "JoinedTeamIds should round-trip");
   }
@@ -83,7 +83,7 @@ class UserRepositoryTest {
 
     User fetched = repo.findById("u4");
     assertEquals("newpass", fetched.getHashedPassword());
-    assertEquals(9, fetched.getSabotagePoints());
+    assertEquals(30, fetched.getSabotagePoints());
     assertTrue(fetched.getJoinedTeamIds().contains("teamX"));
   }
 }

--- a/src/test/java/com/habit/server/service/TaskAutoResetServiceTest.java
+++ b/src/test/java/com/habit/server/service/TaskAutoResetServiceTest.java
@@ -180,9 +180,9 @@ class TaskAutoResetServiceTest {
         final LocalDate today = LocalDate.now(fixedClock);
         final LocalDate yesterday = today.minusDays(1);
 
-        // ユーザーを初期サボりポイント0で作成
+        // ユーザーを初期サボりポイント25で作成
         com.habit.domain.User user = new com.habit.domain.User(userId, "testuser5", "hashedpass");
-        user.setSabotagePoints(0);
+        user.setSabotagePoints(25);
         userRepository.save(user);
 
         // 毎日繰り返しのタスクを作成
@@ -197,10 +197,10 @@ class TaskAutoResetServiceTest {
         taskAutoResetService.checkAndResetTasks(teamId, today);
 
         // --- Then (検証) ---
-        // サボりポイントが1増加していることを確認
+        // サボりポイントが5増加していることを確認
         com.habit.domain.User updatedUser = userRepository.findById(userId);
         assertNotNull(updatedUser);
-        assertEquals(1, updatedUser.getSabotagePoints(), "未完了タスクでサボりポイントが1増加するはず");
+        assertEquals(30, updatedUser.getSabotagePoints(), "未完了タスクでサボりポイントが5増加するはず");
 
         // システムメッセージが送信されていることを確認
         List<MessageRepository.MessageEntry> messages = messageRepository.findMessagesByteamID(teamId, 10); // findByTeamId -> findMessagesByteamID, limit追加


### PR DESCRIPTION
サボりポイントの仕様を調整し、タスク達成・未達成によるキャラクターレベルや嫌がらせポップアップの変化をより段階的に、かつ意図した通りに反映されるように改善しました。

  変更内容

  1. サボりポイントの基本仕様変更


   * `User.java`:
       * sabotagePointsの初期値を25に設定しました。
       * addSabotagePointsメソッド内で、サボりポイントが0（最良）から50（最悪）の範囲に収まるように上限・下限を設けるロジックを追加しました。
   * `UserTaskStatusController.java`:
       * タスク達成時、ユーザーのサボりポイントが-1されるように変更しました。
   * `TaskAutoResetService.java`:
       * タスクが未達成（サボり）だった場合、ユーザーのサボりポイントが+5されるように変更しました。

  2. クライアント表示ロジックの調整


   * `HomeController.java` および `TeamTopController.java`:
       * キャラクターレベルの計算: サボりポイントが高いほどキャラクターレベルが低くなるように、計算式を (50 - sabotagePoints) / 5 に変更しました。これにより、ポイントが0ならレベル10、50ならレベル0となります。
       * 嫌がらせポップアップの表示条件: サボりポイントが35以上の場合にポップアップが表示されるように条件を変更しました。
  3. テストコードの修正


   * `UserRepositoryTest.java`:
       * testSaveAndFindByIdおよびtestReplaceOnSaveメソッド内のsabotagePointsの期待値を、新しい仕様（初期値25からの加減算）に合わせて30に修正しました。
   * `TaskAutoResetServiceTest.java`:
       * testSabotagePointsIncreaseOnIncompleteTaskメソッドにおいて、ユーザーの初期サボりポイントを25に設定し、未完了タスクによるポイント増加が+5であることを検証するように修正しました。

  変更の意図


   * サボりポイントの変動をより細かく、段階的にすることで、ユーザー体験を向上させます。
   * タスクをサボった際のペナルティを大きくし、タスク達成のインセンティブを高めます。
   * キャラクターのレベル変化が緩やかになり、ユーザーが自身の進捗をより実感しやすくなります。