### PR TITLE
タスク削除機能の追加

### DIFF
--- a/src/main/java/com/habit/server/HabitServer.java
+++ b/src/main/java/com/habit/server/HabitServer.java
@@ -219,6 +219,8 @@ public class HabitServer {
         teamTaskController
             .getUserTeamTasksHandler()); // ユーザーのチーム共通タスク一覧取得
 
+    server.createContext("/deleteTask", teamTaskController.deleteTaskHandler());
+
     server.setExecutor(null);
     server.start();
 

--- a/src/main/java/com/habit/server/repository/TaskRepository.java
+++ b/src/main/java/com/habit/server/repository/TaskRepository.java
@@ -282,4 +282,50 @@ public class TaskRepository {
     }
     return null;
   }
+
+  /**
+   * タスクIDでタスクを削除する
+   * @param taskId
+   */
+  public void deleteById(String taskId) {
+    Connection conn = null;
+    try {
+        conn = DriverManager.getConnection(databaseUrl);
+        conn.setAutoCommit(false);
+
+        // user_task_statusesテーブルから関連レコードを削除
+        String delUserTaskStatusSql = "DELETE FROM user_task_statuses WHERE taskId = ?";
+        try (PreparedStatement pstmt = conn.prepareStatement(delUserTaskStatusSql)) {
+            pstmt.setString(1, taskId);
+            pstmt.executeUpdate();
+        }
+
+        // tasksテーブルからタスクを削除
+        String delTaskSql = "DELETE FROM tasks WHERE taskId = ?";
+        try (PreparedStatement pstmt = conn.prepareStatement(delTaskSql)) {
+            pstmt.setString(1, taskId);
+            pstmt.executeUpdate();
+        }
+
+        conn.commit();
+    } catch (SQLException e) {
+        e.printStackTrace();
+        if (conn != null) {
+            try {
+                conn.rollback();
+            } catch (SQLException ex) {
+                ex.printStackTrace();
+            }
+        }
+    } finally {
+        if (conn != null) {
+            try {
+                conn.setAutoCommit(true);
+                conn.close();
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+  }
 }

--- a/src/main/java/com/habit/server/service/TeamTaskService.java
+++ b/src/main/java/com/habit/server/service/TeamTaskService.java
@@ -155,4 +155,24 @@ public class TeamTaskService {
     public List<UserTaskStatus> getUserTeamTaskStatuses(String userId, LocalDate date) {
         return userTaskStatusRepository.findByUserIdAndDateAndTeamIdNotNull(userId, date);
     }
+
+    /**
+     * タスクを削除する
+     * @param teamId チームID
+     * @param taskId タスクID
+     * @param userId ユーザーID
+     */
+    public void deleteTask(String teamId, String taskId, String userId) {
+        Team team = teamRepository.findById(teamId);
+        if (team == null) {
+            throw new IllegalArgumentException("チームが見つかりません");
+        }
+
+        // 権限チェック
+        if ("CREATOR_ONLY".equals(team.getEditPermission()) && !team.getCreatorId().equals(userId)) {
+            throw new SecurityException("タスクの削除権限がありません");
+        }
+
+        taskRepository.deleteById(taskId);
+    }
 }


### PR DESCRIPTION
  ## feat. 権限チェック付きタスク削除機能の実装

  ### 概要

  チームのタスクを削除する新機能を実装しました。
  この機能により、ユーザーは不要になったタスクを管理・削除できるようになります。

 ### 主な変更点

  1. タスク削除APIの実装 (サーバーサイド)

   - POST /deleteTask という新しいAPIエンドポイントを追加しました。
   - リクエストボディにteamId, taskId, userIdをJSON形式で含めるように統一しました。
   - TeamTaskServiceに、チームの編集権限 (editPermission) に基づく権限チェックロジックを実装しました。
       - editPermissionがCREATOR_ONLYの場合、チーム作成者のみがタスクを削除できます。
   - TaskRepositoryに、データベースからタスクを削除する処理を実装しました。
       - データの整合性を保つため、tasksテーブルとuser_task_statusesテーブルから関連レコードをトランザクション内で一括削除します。

  2. 削除機能のUI実装 (クライアントサイド)

   - 個人タスク画面 (PersonalPage) の各タスクタイルに、右クリックで表示されるコンテキストメニューを追加しました。
   - クライアント側でも権限チェックを行い、タスクの削除権限を持つユーザーにのみ「削除」メニューが表示されるようにしました。
       - これにより、不要なAPIコールを防ぎ、UXを向上させています。
   - 「削除」を選択すると、誤操作防止のための確認ダイアログが表示されます。
   - 削除が成功すると、UIからタスクタイルが即座に削除されます。権限がない等の理由で失敗した場合は、エラーメッセージが表示されます。

 ### テスト方法

   1. アプリケーションを起動し、個人タスク画面に移動します。
   2. 任意のタスクを右クリックします。
   3. 権限がある場合（チームの編集権限が "全員" or 自分がチーム作成者）、「削除」メニューが表示されることを確認します。
   4. 権限がない場合、「削除」メニューが表示されないことを確認します。
   5. 「削除」をクリックし、確認ダイアログで「OK」を押します。
   6. タスクが画面から消えることを確認します。
   7. アプリケーションを再起動しても、タスクが復元されていない（データベースから削除されている）ことを確認します。