### PR TITLE
Feature/tsuji/task function

### DIFF
--- a/src/main/java/com/habit/client/TaskCreateController.java
+++ b/src/main/java/com/habit/client/TaskCreateController.java
@@ -149,8 +149,18 @@ public class TaskCreateController {
                 .build();
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
             logger.info("タスク保存APIレスポンス: " + response.body());
+
+            if (response.statusCode() == 200) {
+                // 成功時の処理
+            } else if (response.statusCode() == 409) {
+                showAlert("エラー: 同じ名前のタスクが既に存在します。");
+                return;
+            } else {
+                showAlert("タスク保存APIエラー: " + response.statusCode() + " - " + response.body());
+                return;
+            }
         } catch (Exception e) {
-            showAlert("タスク保存APIエラー: " + e.getMessage());
+            showAlert("タスク保存中にエラーが発生しました: " + e.getMessage());
             return;
         }
 

--- a/src/main/java/com/habit/server/HabitServer.java
+++ b/src/main/java/com/habit/server/HabitServer.java
@@ -159,6 +159,11 @@ public class HabitServer {
         "/getIncompleteUserTaskStatus",
         userTaskStatusController.getIncompleteUserTaskStatusHandler(
             authService));
+    // ユーザーの全タスクステータス（最新のみ）取得API
+    server.createContext(
+        "/getAllUserTaskStatus",
+        userTaskStatusController.getAllUserTaskStatusHandler(
+            authService));
     // チーム全員分のタスク進捗一覧API
     server.createContext(
         "/getTeamTaskStatusList",


### PR DESCRIPTION
## feat: タスク表示改善、操作性向上、および重複タスク作成防止機能の追加

 ### 概要:
  本プルリクエストでは、個人ページにおけるタスクの表示方法を改善し、タスク操作のユーザーエクスペリエンスを向上させました。また、チーム内での同名タスクの重複作成を防止する機能を追加し、データの一貫性を強化しました。

 ### 主な変更点:

   1. 個人ページでの完了済みタスク表示機能の追加
       * 目的: ユーザーが自身の完了済みタスクも個人ページで確認できるようにするため。
       * 変更内容:
           * サーバーサイド (`UserTaskStatusController.java`, `HabitServer.java`):
               * 新しいAPIエンドポイント /getAllUserTaskStatus を追加しました。このAPIは、指定されたユーザーとチームのすべてのタスクステータス（完了・未完了問わず）を、各タスクIDごとに最新のステータスのみをフィルタリングして返します。これにより、タスクのリセット後も最新の状態が正しく反映されます。
           * クライアントサイド (`PersonalPageController.java`):
               * タスク取得に新しい /getAllUserTaskStatus APIを使用するように変更しました。
               * APIレスポンスに含まれる isDone フラグに基づき、完了済みタスクは「(完了)」と表示され、グレーアウトされてクリック不可になります。
       * 影響範囲: 個人ページのタスク表示ロジック。TeamTopControllerは既存の未完了タスクAPI(/getIncompleteUserTaskStatus) を引き続き使用するため、影響はありません。


   2. 個人ページでのタスクタイルクリック操作の改善
       * 目的: タスクの達成と削除操作を統一されたメニューから行えるようにし、操作性を向上させるため。
       * 変更内容 (`PersonalPageController.java`):
           * タスクタイル（ボタン）の左クリック時に、タスクの「達成」と「削除」を選択できるコンテキストメニューが表示されるように変更しました。
           * 既存のタスク完了処理と削除処理（確認ダイアログ、API呼び出し、エラーハンドリングを含む）は、このメニュー項目に適切に移行されました。


   3te. 同名タスク作成の防止機能の追加
       * 目的: 同じチーム内で同名のタスクが複数作成されるのを防ぎ、データの一貫性を保つため。
       * 変更内容:
           * サーバーサイド (`TaskController.java`):
               * /saveTask APIの処理において、タスクを保存する前に、同じチーム内に同名のタスクが既に存在しないかを確認するロジックを追加しました。
               * 重複が見つかった場合、HTTPステータス 409 Conflict をクライアントに返します。
           * クライアントサイド (`TaskCreateController.java`):
               * /saveTask APIからのレスポンスをチェックし、409 Conflict が返された場合は「同じ名前のタスクが既に存在します。」というエラーメッセージをユーザーに表示します。


  ### テスト方法:

       * 未完了のタスクタイルを左クリックし、「タスクを達成」と「削除」のメニューが表示されることを確認します。
       
       * 「タスクを達成」を選択し、確認ダイアログが表示され、タスクが完了状態になることを確認します。このとき画面が更新されてタスクが「(完了)」と表示され、グレーアウトされていることを確認します。
       * 完了済みタスクがクリックできないことを確認します。
       
       * 「削除」を選択し、確認ダイアログが表示され、タスクが削除されることを確認します。
       * チームの編集権限が「自分だけ」の場合、自分が作成したタスク以外では「削除」メニューが表示されないことを確認します。
       * タスクを削除した後、 個人ページからそのタスクが即座に消えることを確認します。

       * 同じチーム内で、既に存在しているタスク名でタスクを作成しようとし、「エラー: 同じ名前のタスクが既に存在します。」というアラートが表示され、タスクが作成されないことを確認します。
       * 異なるタスク名であれば、問題なく作成できることを確認します。